### PR TITLE
Spec out crypto primitives

### DIFF
--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -206,6 +206,8 @@ Consensus-critical data is authenticated using [ECDSA](https://www.secg.org/sec1
 
 [Public key](#publickey)s are encoded in uncompressed form, as the concatenation of the `x` and `y` values. No prefix is needed to distinguish between encoding schemes as this is the only encoding supported.
 
+Deterministic signatures ([RFC-6979](https://tools.ietf.org/rfc/rfc6979.txt)) should be used when signing, but this is not enforced at the protocol level as it cannot be.
+
 [Signature](#signature)s are represented as the `r` and `s` (each 32 bytes), and `v` (1-bit) values of the signature. `r` and `s` take on their usual meaning (see: [SEC 1, 4.1.3 Signing Operation](https://www.secg.org/sec1-v2.pdf)), while `v` is used for recovering the public key from a signature more quickly (see: [SEC 1, 4.1.6 Public Key Recovery Operation](https://www.secg.org/sec1-v2.pdf)). Only low-`s` values in signatures are valid (i.e. `s <= secp256k1.n//2`); `s` can be replaced with `-s mod secp256k1.n` during the signing process if it is high. Given this, the first bit of `s` will always be `0`, and can be used to store the 1-bit `v` value.
 
 `v` represents the parity of the `Y` component of the point, `0` for even and `1` for odd. The `X` component of the point is assumed to always be low, since [the possibility of it being high is negligible](https://bitcoin.stackexchange.com/questions/38351/ecdsa-v-r-s-what-is-v).

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -202,13 +202,21 @@ Unless otherwise indicated explicitly, objects are first [serialized](#serializa
 
 # Public-Key Cryptography
 
-Consensus-critical data is authenticated using [ECDSA](https://www.secg.org/sec1-v2.pdf), with the curve [secp256k1](https://en.bitcoin.it/wiki/Secp256k1). A highly-optimized library is available in C (https://github.com/bitcoin-core/secp256k1).
+Consensus-critical data is authenticated using [ECDSA](https://www.secg.org/sec1-v2.pdf), with the curve [secp256k1](https://en.bitcoin.it/wiki/Secp256k1). A highly-optimized library is available in C (https://github.com/bitcoin-core/secp256k1), with wrappers in Go (https://pkg.go.dev/github.com/ethereum/go-ethereum/crypto/secp256k1) and Rust (https://crates.io/crates/secp256k1).
 
-[Public key](#publickey)s are encoded in uncompressed form, as the concatenation of the `x` and `y` values. No prefix is needed as this is the only encoding supported.
+[Public key](#publickey)s are encoded in uncompressed form, as the concatenation of the `x` and `y` values. No prefix is needed to distinguish between encoding schemes as this is the only encoding supported.
 
-[Signature](#signature)s are encoded as the `r` and `s` values of the signature, with one twist. Only low-`s` values in signatures are valid (i.e. `s < secp256k1.n`); `s` can be replaced with `-s mod secp256k1.n` during the signing process if it is high. Given this, the first bit of `s` will always be `0`, and can be used to store the 1-bit `v` value.
+[Signature](#signature)s are represented as the `r` and `s` (each 32 bytes), and `v` (1-bit) values of the signature. `r` and `s` take on their usual meaning (see: [SEC 1, 4.1.3 Signing Operation](https://www.secg.org/sec1-v2.pdf)), while `v` is used for recovering the public key from a signature more quickly (see: [SEC 1, 4.1.6 Public Key Recovery Operation](https://www.secg.org/sec1-v2.pdf)). Only low-`s` values in signatures are valid (i.e. `s <= secp256k1.n//2`); `s` can be replaced with `-s mod secp256k1.n` during the signing process if it is high. Given this, the first bit of `s` will always be `0`, and can be used to store the 1-bit `v` value.
 
-This encoding for signatures is inspired by [EIP 2098: Compact Signature Representation](https://eips.ethereum.org/EIPS/eip-2098).
+`v` represents the parity of the `Y` component of the point, `0` for even and `1` for odd. The `X` component of the point is assumed to always be low, since [the possibility of it being high is negligible](https://bitcoin.stackexchange.com/questions/38351/ecdsa-v-r-s-what-is-v).
+
+Putting it all together, the encoding for signatures is:
+```
+|    32 bytes   ||           32 bytes           |
+[256-bit r value][1-bit v value][255-bit s value]
+```
+
+This encoding scheme is derived from [EIP 2098: Compact Signature Representation](https://eips.ethereum.org/EIPS/eip-2098).
 
 # Merkle Trees
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -202,7 +202,7 @@ Unless otherwise indicated explicitly, objects are first [serialized](#serializa
 
 # Public-Key Cryptography
 
-Consensus-critical data is authenticated using [ECDSA](https://www.secg.org/sec1-v2.pdf), with the curve [secp256k1](https://en.bitcoin.it/wiki/Secp256k1). A highly-optimized library is available in C (https://github.com/bitcoin-core/secp256k1), with wrappers in Go (https://pkg.go.dev/github.com/ethereum/go-ethereum/crypto/secp256k1) and Rust (https://crates.io/crates/secp256k1).
+Consensus-critical data is authenticated using [ECDSA](https://www.secg.org/sec1-v2.pdf), with the curve [secp256k1](https://en.bitcoin.it/wiki/Secp256k1). A highly-optimized library is available in C (https://github.com/bitcoin-core/secp256k1), with wrappers in Go (https://pkg.go.dev/github.com/ethereum/go-ethereum/crypto/secp256k1) and Rust (https://docs.rs/crate/secp256k1).
 
 [Public key](#publickey)s are encoded in uncompressed form, as the concatenation of the `x` and `y` values. No prefix is needed to distinguish between encoding schemes as this is the only encoding supported.
 


### PR DESCRIPTION
Related issue: #8.

- [x] Public-key crypto encoding
- [ ] Vote serialization (https://github.com/LazyLedger/lazyledger-specs/pull/2#discussion_r377012152)
- [ ] Merkle trees (need a generic annotated Merkle tree)