### PR TITLE
Fix link to citation for low-probability of X being low for signatures

### DIFF
--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -210,7 +210,7 @@ Deterministic signatures ([RFC-6979](https://tools.ietf.org/rfc/rfc6979.txt)) sh
 
 [Signature](#signature)s are represented as the `r` and `s` (each 32 bytes), and `v` (1-bit) values of the signature. `r` and `s` take on their usual meaning (see: [SEC 1, 4.1.3 Signing Operation](https://www.secg.org/sec1-v2.pdf)), while `v` is used for recovering the public key from a signature more quickly (see: [SEC 1, 4.1.6 Public Key Recovery Operation](https://www.secg.org/sec1-v2.pdf)). Only low-`s` values in signatures are valid (i.e. `s <= secp256k1.n//2`); `s` can be replaced with `-s mod secp256k1.n` during the signing process if it is high. Given this, the first bit of `s` will always be `0`, and can be used to store the 1-bit `v` value.
 
-`v` represents the parity of the `Y` component of the point, `0` for even and `1` for odd. The `X` component of the point is assumed to always be low, since [the possibility of it being high is negligible](https://bitcoin.stackexchange.com/questions/38351/ecdsa-v-r-s-what-is-v).
+`v` represents the parity of the `Y` component of the point, `0` for even and `1` for odd. The `X` component of the point is assumed to always be low, since [the possibility of it being high is negligible](https://bitcoin.stackexchange.com/a/38909).
 
 Putting it all together, the encoding for signatures is:
 ```


### PR DESCRIPTION
Link directly to SO answer instead of question.