### PR TITLE
Specify enum sizes

### DIFF
--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -138,7 +138,7 @@ Addresses are the last `20` bytes of the [hash](#hashing) [digest](#hashdigest) 
 ## CommitSig
 
 ```C++
-enum BlockIDFlag {
+enum BlockIDFlag : uint8_t {
     BlockIDFlagAbsent = 1,
     BlockIDFlagCommit = 2,
     BlockIDFlagNil = 3,
@@ -162,7 +162,7 @@ enum BlockIDFlag {
 ## Vote
 
 ```C++
-enum VoteType {
+enum VoteType : uint8_t {
     Prevote = 1,
     Precommit = 2,
 };

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -139,9 +139,9 @@ Addresses are the last `20` bytes of the [hash](#hashing) [digest](#hashdigest) 
 
 ```C++
 enum BlockIDFlag {
-    BlockIDFlagAbsent = 0x01,
-    BlockIDFlagCommit = 0x02,
-    BlockIDFlagNil = 0x03,
+    BlockIDFlagAbsent = 1,
+    BlockIDFlagCommit = 2,
+    BlockIDFlagNil = 3,
 };
 ```
 


### PR DESCRIPTION
Explicitly specify enums as unsigned 8-bit (i.e. 1-byte) ints.