### PR TITLE
Fix namespace ID type

### DIFF
--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -5,7 +5,7 @@ Consensus Rules
 - [System Parameters](#system-parameters)
   - [Units](#units)
   - [Constants](#constants)
-  - [Types](#types)
+  - [Type Aliases](#type-aliases)
   - [Reserved Namespace IDs](#reserved-namespace-ids)
   - [Reserved State Subtree IDs](#reserved-state-subtree-ids)
   - [Rewards and Penalties](#rewards-and-penalties)
@@ -44,12 +44,12 @@ Consensus Rules
 | `MAX_VALIDATORS`                      | `uint16` | `64`    |         | Maximum number of active validators.                                                                                                                        |
 | `STATE_SUBTREE_RESERVED_BYTES`        | `uint64` | `1`     | `byte`  | Number of bytes reserved to identify state subtrees.                                                                                                        |
 
-## Types
+## Type Aliases
 
-| name             | type     |
-| ---------------- | -------- |
-| `NamespaceID`    | `uint64` |
-| `StateSubtreeID` | `byte`   |
+| name             | type                       |
+| ---------------- | -------------------------- |
+| `NamespaceID`    | `byte[NAMESPACE_ID_BYTES]` |
+| `StateSubtreeID` | `byte`                     |
 
 ## Reserved Namespace IDs
 


### PR DESCRIPTION
From incorrect `uint64` to fixed-size byte array.