### PR TITLE
Merkle tree misc fixes

### DIFF
--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -251,6 +251,13 @@ Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepend
 
 [Shares](#share) in LazyLedger are associated with a provided _namespace ID_. The Namespace Merkle Tree (NMT) is a variation of the [Merkle Interval Tree](https://eprint.iacr.org/2018/642), which is itself an extension of the [Merkle Sum Tree](https://bitcointalk.org/index.php?topic=845978.0). It allows for compact proofs around the inclusion of exclusion of shares with particular namespace IDs.
 
+The base case (an empty tree) is defined as:
+```C++
+n_min = 0x0000000000000000000000000000000000000000000000000000000000000000
+n_max = 0x0000000000000000000000000000000000000000000000000000000000000000
+v = 0x0000000000000000000000000000000000000000000000000000000000000000
+```
+
 For leaf node of data `d`:
 ```C++
 n_min = d.namespaceID

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -231,6 +231,11 @@ Merkle trees are used to authenticate various pieces of data across the LazyLedg
 
 Binary Merkle trees are constructed in the same fashion as described in [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962). Leaves are hashed once to get leaf node values and internal node values are the hash of the concatenation of their children (either leaf nodes or other internal nodes).
 
+Nodes contain a single field:
+| name | type       | description |
+| ---- | ---------- | ----------- |
+| `v`  | `byte[32]` | Node value. |
+
 The base case (an empty tree) is defined as zero:
 ```C++
 node.v = 0x0000000000000000000000000000000000000000000000000000000000000000
@@ -262,6 +267,13 @@ Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepend
 ## Namespace Merkle Tree
 
 [Shares](#share) in LazyLedger are associated with a provided _namespace ID_. The Namespace Merkle Tree (NMT) is a variation of the [Merkle Interval Tree](https://eprint.iacr.org/2018/642), which is itself an extension of the [Merkle Sum Tree](https://bitcointalk.org/index.php?topic=845978.0). It allows for compact proofs around the inclusion or exclusion of shares with particular namespace IDs.
+
+Nodes contain three fields:
+| name    | type                         | description                                      |
+| ------- | ---------------------------- | ------------------------------------------------ |
+| `n_min` | [NamespaceID](#type-aliases) | Min namespace ID in subtree rooted at this node. |
+| `n_max` | [NamespaceID](#type-aliases) | Max namespace ID in subtree rooted at this node. |
+| `v`     | `byte[32]`                   | Node value.                                      |
 
 The base case (an empty tree) is defined as:
 ```C++
@@ -305,6 +317,11 @@ Additional rules are added on top of plain [binary Merkle trees](#binary-merkle-
 1. Default values are given to leaf nodes with empty leaves.
 1. While the above rule is sufficient to pre-compute the values of intermediate nodes that are roots of empty subtrees, a further simplification is to extend this default value to all nodes that are roots of empty subtrees. The 32-byte zero, i.e. `0x0000000000000000000000000000000000000000000000000000000000000000`, is used as the default value. This rule takes precedence over the above one.
 1. The number of hashing operations can be reduced to be logarithmic in the number of non-empty leaves on average, assuming a uniform distribution of non-empty leaf keys. An internal node that is the root of a subtree that contains exactly one non-empty leaf is replaced by that leaf's leaf node.
+
+Nodes contain a single field:
+| name | type       | description |
+| ---- | ---------- | ----------- |
+| `v`  | `byte[32]` | Node value. |
 
 The base case (an empty tree) is defined as the default value:
 ```C++

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -21,7 +21,9 @@ Data Structures
 - [Public-Key Cryptography](#public-key-cryptography)
 - [Merkle Trees](#merkle-trees)
   - [Binary Merkle Tree](#binary-merkle-tree)
+    - [Binary Merkle Tree Proofs](#binary-merkle-tree-proofs)
   - [Namespace Merkle Tree](#namespace-merkle-tree)
+    - [Namespace Merkle Tree Proofs](#namespace-merkle-tree-proofs)
   - [Sparse Merkle Tree](#sparse-merkle-tree)
     - [Sparse Merkle Tree Proofs](#sparse-merkle-tree-proofs)
 - [Erasure Coding](#erasure-coding)
@@ -248,6 +250,16 @@ Note that rather than duplicating the last node if there are an odd number of no
 
 Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepended for leaf nodes while `0x01` is prepended for internal nodes. This avoids a second-preimage attack [where internal nodes are presented as leaves](https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack) trees with leaves at different heights.
 
+### Binary Merkle Tree Proofs
+
+| name       | type                          | description                                                              |
+| ---------- | ----------------------------- | ------------------------------------------------------------------------ |
+| `root`     | [HashDigest](#hashdigest)     | Merkle root.                                                             |
+| `key`      | `byte[32]`                    | Key (i.e. index) of the leaf.                                            |
+| `depth`    | `uint16`                      | Depth of the leaf node. The root node is at depth `0`. Must be `<= 256`. |
+| `siblings` | [HashDigest](#hashdigest)`[]` | Sibling hash values.                                                     |
+| `leaf`     | `byte[]`                      | Leaf value.                                                              |
+
 ## Namespace Merkle Tree
 
 [Shares](#share) in LazyLedger are associated with a provided _namespace ID_. The Namespace Merkle Tree (NMT) is a variation of the [Merkle Interval Tree](https://eprint.iacr.org/2018/642), which is itself an extension of the [Merkle Sum Tree](https://bitcointalk.org/index.php?topic=845978.0). It allows for compact proofs around the inclusion of exclusion of shares with particular namespace IDs.
@@ -274,6 +286,18 @@ n_min = min(l.n_min, r.n_min)
 n_max = max(l.n_max, r.n_max)
 v = h(l, r) = h(0x01, l.n_min, l.n_max, l.v, r.n_min, r.n_max, r.v)
 ```
+
+### Namespace Merkle Tree Proofs
+
+| name            | type                             | description                                                              |
+| --------------- | -------------------------------- | ------------------------------------------------------------------------ |
+| `root`          | [HashDigest](#hashdigest)        | Merkle root.                                                             |
+| `key`           | `byte[32]`                       | Key (i.e. index) of the leaf.                                            |
+| `depth`         | `uint16`                         | Depth of the leaf node. The root node is at depth `0`. Must be `<= 256`. |
+| `siblingValues` | [HashDigest](#hashdigest)`[]`    | Sibling hash values.                                                     |
+| `siblingMins`   | [NamespaceID](#type-aliases)`[]` | Sibling min namespaceIDs.                                                |
+| `siblingMaxs`   | [NamespaceID](#type-aliases)`[]` | Sibling max namespaceIDs.                                                |
+| `leaf`          | `byte[]`                         | Leaf value.                                                              |
 
 ## Sparse Merkle Tree
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -279,18 +279,16 @@ For a Merkle branch of height `h`, an `h`-bit value is appended to the proof. Th
 
 Finally, the number of hashing operations can be reduced to be logarithmic in the number of non-empty leaves on average. An internal node that is the root of a subtree that contains exactly one non-empty leaf is replaced by that leaf's leaf node.
 
-This creates an imbalanced tree with leaf nodes at different heights, so leaves and nodes must be hashed differently to avoid a second-preimage attack [where internal nodes are presented as leaf nodes](https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack). When hashing leaves, the `uint8` value `0x00` is prepended to the leaf value, and when hashing nodes, `0x01` is prepended to the hash value.
-
 Additionally, the key of leaf nodes must be prepended, since the index of a leaf node that is not at the base of the tree cannot be determined without this information.
 
-For leaf node of leaf message `m` with key `k`, its value `v` is:
+For leaf node of leaf data `d` with key `k`, its value `v` is:
 ```C++
-v = h(`0x00`, k, serialize(m))
+v = h(0x00, k, serialize(d))
 ```
 
 For internal node with children `l` and `r`, its value `v` is:
 ```C++
-v = h(`0x01`, l.v, r.v)
+v = h(0x01, l.v, r.v)
 ```
 
 A proof into an SMT is structured as:

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -233,17 +233,17 @@ Binary Merkle trees are constructed in the same fashion as described in [Certifi
 
 The base case (an empty tree) is defined as zero:
 ```C++
-v = 0x0000000000000000000000000000000000000000000000000000000000000000
+node.v = 0x0000000000000000000000000000000000000000000000000000000000000000
 ```
 
-For leaf node of leaf data `d`, its value `v` is:
+For leaf node `node` of leaf data `d`, its value `v` is:
 ```C++
-v = h(0x00, serialize(d))
+node.v = h(0x00, serialize(d))
 ```
 
-For internal node with children `l` and `r`, its value `v` is:
+For internal node `node` with children `l` and `r`, its value `v` is:
 ```C++
-v = h(0x01, l.v, r.v)
+node.v = h(0x01, l.v, r.v)
 ```
 
 Note that rather than duplicating the last node if there are an odd number of nodes (the [Bitcoin design](https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/consensus/merkle.cpp#L9-L43)), trees are allowed to be imbalanced. In other words, the height of each leaf may be different. For an example, see Section 2.1.3 of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962).
@@ -265,25 +265,25 @@ Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepend
 
 The base case (an empty tree) is defined as:
 ```C++
-n_min = 0x0000000000000000000000000000000000000000000000000000000000000000
-n_max = 0x0000000000000000000000000000000000000000000000000000000000000000
-v = 0x0000000000000000000000000000000000000000000000000000000000000000
+node.n_min = 0x0000000000000000000000000000000000000000000000000000000000000000
+node.n_max = 0x0000000000000000000000000000000000000000000000000000000000000000
+node.v = 0x0000000000000000000000000000000000000000000000000000000000000000
 ```
 
-For leaf node of data `d`:
+For leaf node `node` of data `d`:
 ```C++
-n_min = d.namespaceID
-n_max = d.namespaceID
-v = h(0x00, serialize(d)
+node.n_min = d.namespaceID
+node.n_max = d.namespaceID
+node.v = h(0x00, serialize(d)
 ```
 
 The `namespaceID` message field here is the namespace ID of the leaf, which is a [`NAMESPACE_ID_BYTES`](consensus.md#system-parameters)-long byte array.
 
-For internal node with children `l` and `r`:
+For internal node `node` with children `l` and `r`:
 ```C++
-n_min = min(l.n_min, r.n_min)
-n_max = max(l.n_max, r.n_max)
-v = h(l, r) = h(0x01, l.n_min, l.n_max, l.v, r.n_min, r.n_max, r.v)
+node.n_min = min(l.n_min, r.n_min)
+node.n_max = max(l.n_max, r.n_max)
+node.v = h(l, r) = h(0x01, l.n_min, l.n_max, l.v, r.n_min, r.n_max, r.v)
 ```
 
 ### Namespace Merkle Tree Proofs
@@ -308,19 +308,19 @@ Additional rules are added on top of plain [binary Merkle trees](#binary-merkle-
 
 The base case (an empty tree) is defined as the default value:
 ```C++
-v = 0x0000000000000000000000000000000000000000000000000000000000000000
+node.v = 0x0000000000000000000000000000000000000000000000000000000000000000
 ```
 
-For leaf node of leaf data `d` with key `k`, its value `v` is:
+For leaf node `node` of leaf data `d` with key `k`, its value `v` is:
 ```C++
-v = h(0x00, k, serialize(d))
+node.v = h(0x00, k, serialize(d))
 ```
 
 The key of leaf nodes must be prepended, since the index of a leaf node that is not at the base of the tree cannot be determined without this information.
 
-For internal node with children `l` and `r`, its value `v` is:
+For internal node `node` with children `l` and `r`, its value `v` is:
 ```C++
-v = h(0x01, l.v, r.v)
+node.v = h(0x01, l.v, r.v)
 ```
 
 ### Sparse Merkle Tree Proofs

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -288,6 +288,11 @@ Finally, the number of hashing operations can be reduced to be logarithmic in th
 
 Additionally, the key of leaf nodes must be prepended, since the index of a leaf node that is not at the base of the tree cannot be determined without this information.
 
+The base case (an empty tree) is defined as:
+```C++
+v = 0x0000000000000000000000000000000000000000000000000000000000000000
+```
+
 For leaf node of leaf data `d` with key `k`, its value `v` is:
 ```C++
 v = h(0x00, k, serialize(d))

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -241,12 +241,12 @@ The base case (an empty tree) is defined as zero:
 node.v = 0x0000000000000000000000000000000000000000000000000000000000000000
 ```
 
-For leaf node `node` of leaf data `d`, its value `v` is:
+For leaf node `node` of leaf data `d`:
 ```C++
 node.v = h(0x00, serialize(d))
 ```
 
-For internal node `node` with children `l` and `r`, its value `v` is:
+For internal node `node` with children `l` and `r`:
 ```C++
 node.v = h(0x01, l.v, r.v)
 ```
@@ -328,14 +328,14 @@ The base case (an empty tree) is defined as the default value:
 node.v = 0x0000000000000000000000000000000000000000000000000000000000000000
 ```
 
-For leaf node `node` of leaf data `d` with key `k`, its value `v` is:
+For leaf node `node` of leaf data `d` with key `k`:
 ```C++
 node.v = h(0x00, k, serialize(d))
 ```
 
 The key of leaf nodes must be prepended, since the index of a leaf node that is not at the base of the tree cannot be determined without this information.
 
-For internal node `node` with children `l` and `r`, its value `v` is:
+For internal node `node` with children `l` and `r`:
 ```C++
 node.v = h(0x01, l.v, r.v)
 ```

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -252,13 +252,12 @@ Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepend
 
 ### Binary Merkle Tree Proofs
 
-| name       | type                          | description                                                              |
-| ---------- | ----------------------------- | ------------------------------------------------------------------------ |
-| `root`     | [HashDigest](#hashdigest)     | Merkle root.                                                             |
-| `key`      | `byte[32]`                    | Key (i.e. index) of the leaf.                                            |
-| `depth`    | `uint16`                      | Depth of the leaf node. The root node is at depth `0`. Must be `<= 256`. |
-| `siblings` | [HashDigest](#hashdigest)`[]` | Sibling hash values.                                                     |
-| `leaf`     | `byte[]`                      | Leaf value.                                                              |
+| name       | type                          | description                   |
+| ---------- | ----------------------------- | ----------------------------- |
+| `root`     | [HashDigest](#hashdigest)     | Merkle root.                  |
+| `key`      | `byte[32]`                    | Key (i.e. index) of the leaf. |
+| `siblings` | [HashDigest](#hashdigest)`[]` | Sibling hash values.          |
+| `leaf`     | `byte[]`                      | Leaf value.                   |
 
 ## Namespace Merkle Tree
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -274,7 +274,7 @@ For leaf node of data `d`:
 ```C++
 n_min = d.namespaceID
 n_max = d.namespaceID
-v = h(0x00, serialize(m))
+v = h(0x00, serialize(d)
 ```
 
 The `namespaceID` message field here is the namespace ID of the leaf, which is a [`NAMESPACE_ID_BYTES`](consensus.md#system-parameters)-long byte array.

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -298,16 +298,22 @@ node.n_max = max(l.n_max, r.n_max)
 node.v = h(l, r) = h(0x01, serialize(l), serialize(r))
 ```
 
+A root hash can be computed by taking the [hash](#hashing) of the [serialized](#serialization) root node.
+
 ### Namespace Merkle Tree Proofs
 
-| name            | type                             | description                   |
-| --------------- | -------------------------------- | ----------------------------- |
-| `root`          | [HashDigest](#hashdigest)        | Merkle root.                  |
-| `key`           | `byte[32]`                       | Key (i.e. index) of the leaf. |
-| `siblingValues` | [HashDigest](#hashdigest)`[]`    | Sibling hash values.          |
-| `siblingMins`   | [NamespaceID](#type-aliases)`[]` | Sibling min namespace IDs.    |
-| `siblingMaxes`  | [NamespaceID](#type-aliases)`[]` | Sibling max namespace IDs.    |
-| `leaf`          | `byte[]`                         | Leaf value.                   |
+| name                 | type                             | description                   |
+| -------------------- | -------------------------------- | ----------------------------- |
+| `rootHash`           | [HashDigest](#hashdigest)        | Root hash.                    |
+| `rootNamespaceIDMin` | [NamespaceID](#type-aliases)     | Root minimum namespace ID.    |
+| `rootNamespaceIDMax` | [NamespaceID](#type-aliases)     | Root maximum namespace ID.    |
+| `key`                | `byte[32]`                       | Key (i.e. index) of the leaf. |
+| `siblingValues`      | [HashDigest](#hashdigest)`[]`    | Sibling hash values.          |
+| `siblingMins`        | [NamespaceID](#type-aliases)`[]` | Sibling min namespace IDs.    |
+| `siblingMaxes`       | [NamespaceID](#type-aliases)`[]` | Sibling max namespace IDs.    |
+| `leaf`               | `byte[]`                         | Leaf value.                   |
+
+When verifying a NMT proof, the root hash is checked by reconstructing the root node `root_node` with the computed `root_node.v` (computed as with a [plain Merkle proof](#binary-merkle-tree-proofs)) and the provided `rootNamespaceIDMin` and `rootNamespaceIDMax` as the `root_node.n_min` and `root_node.n_max`, respectively.
 
 ## Sparse Merkle Tree
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -230,6 +230,11 @@ Merkle trees are used to authenticate various pieces of data across the LazyLedg
 
 Binary Merkle trees are constructed in the same fashion as described in [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962). Leaves are hashed once to get leaf node values and internal node values are the hash of the concatenation of their children (either leaf nodes or other internal nodes).
 
+The base case (an empty tree) is defined as zero:
+```C++
+v = 0x0000000000000000000000000000000000000000000000000000000000000000
+```
+
 For leaf node of leaf data `d`, its value `v` is:
 ```C++
 v = h(0x00, serialize(d))

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -261,7 +261,7 @@ Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepend
 
 ## Namespace Merkle Tree
 
-[Shares](#share) in LazyLedger are associated with a provided _namespace ID_. The Namespace Merkle Tree (NMT) is a variation of the [Merkle Interval Tree](https://eprint.iacr.org/2018/642), which is itself an extension of the [Merkle Sum Tree](https://bitcointalk.org/index.php?topic=845978.0). It allows for compact proofs around the inclusion of exclusion of shares with particular namespace IDs.
+[Shares](#share) in LazyLedger are associated with a provided _namespace ID_. The Namespace Merkle Tree (NMT) is a variation of the [Merkle Interval Tree](https://eprint.iacr.org/2018/642), which is itself an extension of the [Merkle Sum Tree](https://bitcointalk.org/index.php?topic=845978.0). It allows for compact proofs around the inclusion or exclusion of shares with particular namespace IDs.
 
 The base case (an empty tree) is defined as:
 ```C++

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -286,7 +286,7 @@ For leaf node `node` of data `d`:
 ```C++
 node.n_min = d.namespaceID
 node.n_max = d.namespaceID
-node.v = h(0x00, serialize(d)
+node.v = h(0x00, serialize(d))
 ```
 
 The `namespaceID` message field here is the namespace ID of the leaf, which is a [`NAMESPACE_ID_BYTES`](consensus.md#system-parameters)-long byte array.

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -248,7 +248,7 @@ node.v = h(0x00, serialize(d))
 
 For internal node `node` with children `l` and `r`:
 ```C++
-node.v = h(0x01, l.v, r.v)
+node.v = h(0x01, serialize(l), serialize(r))
 ```
 
 Note that rather than duplicating the last node if there are an odd number of nodes (the [Bitcoin design](https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/consensus/merkle.cpp#L9-L43)), trees are allowed to be imbalanced. In other words, the height of each leaf may be different. For an example, see Section 2.1.3 of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962).
@@ -295,7 +295,7 @@ For internal node `node` with children `l` and `r`:
 ```C++
 node.n_min = min(l.n_min, r.n_min)
 node.n_max = max(l.n_max, r.n_max)
-node.v = h(l, r) = h(0x01, l.n_min, l.n_max, l.v, r.n_min, r.n_max, r.v)
+node.v = h(l, r) = h(0x01, serialize(l), serialize(r))
 ```
 
 ### Namespace Merkle Tree Proofs
@@ -337,7 +337,7 @@ The key of leaf nodes must be prepended, since the index of a leaf node that is 
 
 For internal node `node` with children `l` and `r`:
 ```C++
-node.v = h(0x01, l.v, r.v)
+node.v = h(0x01, serialize(l), serialize(r))
 ```
 
 ### Sparse Merkle Tree Proofs

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -228,19 +228,19 @@ Merkle trees are used to authenticate various pieces of data across the LazyLedg
 
 ## Binary Merkle Tree
 
-Binary Merkle trees are constructed in the usual fashion, with leaves being hashed once to get leaf node values and internal node values being the hash of the concatenation of their children. The specific mechanism for hashing leaves for leaf nodes and children for internal nodes may be different (see: [annotated Merkle trees](#annotated-merkle-tree)), but for plain binary Merkle trees are the same.
+Binary Merkle trees are constructed in the same fashion as described in [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962). Leaves are hashed once to get leaf node values and internal node values are the hash of the concatenation of their children (either leaf nodes or other internal nodes).
 
-For leaf node of leaf message `m`, its value `v` is:
+For leaf node of leaf data `d`, its value `v` is:
 ```C++
-v = h(serialize(m))
+v = h(0x00, serialize(d))
 ```
-
-An exception is made, in the case of empty leaves: the value of a leaf node with an empty leaf is 32-byte zero, i.e. `0x0000000000000000000000000000000000000000000000000000000000000000`. This is used rather than duplicating the last node if there are an odd number of nodes (the [Bitcoin design](https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/consensus/merkle.cpp#L9-L43)) to avoid the complexities in that design, which resulted in e.g. [CVE-2012-2459](https://nvd.nist.gov/vuln/detail/CVE-2012-2459). By constructions, trees are implicitly padded with empty leaves up to the smallest enclosing power of 2.
 
 For internal node with children `l` and `r`, its value `v` is:
 ```C++
-v = h(l.v, r.v)
+v = h(0x01, l.v, r.v)
 ```
+
+Note that rather than duplicating the last node if there are an odd number of nodes (the [Bitcoin design](https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/consensus/merkle.cpp#L9-L43)), trees are allowed to be imbalanced. In other words, the height of each leaf may be different. For an example, see Section 2.1.3. of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962).
 
 ## Annotated Merkle Tree
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -246,7 +246,7 @@ For internal node with children `l` and `r`, its value `v` is:
 v = h(0x01, l.v, r.v)
 ```
 
-Note that rather than duplicating the last node if there are an odd number of nodes (the [Bitcoin design](https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/consensus/merkle.cpp#L9-L43)), trees are allowed to be imbalanced. In other words, the height of each leaf may be different. For an example, see Section 2.1.3. of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962).
+Note that rather than duplicating the last node if there are an odd number of nodes (the [Bitcoin design](https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/consensus/merkle.cpp#L9-L43)), trees are allowed to be imbalanced. In other words, the height of each leaf may be different. For an example, see Section 2.1.3 of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962).
 
 Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepended for leaf nodes while `0x01` is prepended for internal nodes. This avoids a second-preimage attack [where internal nodes are presented as leaves](https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack) trees with leaves at different heights.
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -288,15 +288,14 @@ v = h(l, r) = h(0x01, l.n_min, l.n_max, l.v, r.n_min, r.n_max, r.v)
 
 ### Namespace Merkle Tree Proofs
 
-| name            | type                             | description                                                              |
-| --------------- | -------------------------------- | ------------------------------------------------------------------------ |
-| `root`          | [HashDigest](#hashdigest)        | Merkle root.                                                             |
-| `key`           | `byte[32]`                       | Key (i.e. index) of the leaf.                                            |
-| `depth`         | `uint16`                         | Depth of the leaf node. The root node is at depth `0`. Must be `<= 256`. |
-| `siblingValues` | [HashDigest](#hashdigest)`[]`    | Sibling hash values.                                                     |
-| `siblingMins`   | [NamespaceID](#type-aliases)`[]` | Sibling min namespace IDs.                                               |
-| `siblingMaxes`  | [NamespaceID](#type-aliases)`[]` | Sibling max namespace IDs.                                               |
-| `leaf`          | `byte[]`                         | Leaf value.                                                              |
+| name            | type                             | description                   |
+| --------------- | -------------------------------- | ----------------------------- |
+| `root`          | [HashDigest](#hashdigest)        | Merkle root.                  |
+| `key`           | `byte[32]`                       | Key (i.e. index) of the leaf. |
+| `siblingValues` | [HashDigest](#hashdigest)`[]`    | Sibling hash values.          |
+| `siblingMins`   | [NamespaceID](#type-aliases)`[]` | Sibling min namespace IDs.    |
+| `siblingMaxes`  | [NamespaceID](#type-aliases)`[]` | Sibling max namespace IDs.    |
+| `leaf`          | `byte[]`                         | Leaf value.                   |
 
 ## Sparse Merkle Tree
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -232,9 +232,9 @@ Merkle trees are used to authenticate various pieces of data across the LazyLedg
 Binary Merkle trees are constructed in the same fashion as described in [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962). Leaves are hashed once to get leaf node values and internal node values are the hash of the concatenation of their children (either leaf nodes or other internal nodes).
 
 Nodes contain a single field:
-| name | type       | description |
-| ---- | ---------- | ----------- |
-| `v`  | `byte[32]` | Node value. |
+| name | type                      | description |
+| ---- | ------------------------- | ----------- |
+| `v`  | [HashDigest](#hashdigest) | Node value. |
 
 The base case (an empty tree) is defined as zero:
 ```C++
@@ -273,7 +273,7 @@ Nodes contain three fields:
 | ------- | ---------------------------- | ------------------------------------------------ |
 | `n_min` | [NamespaceID](#type-aliases) | Min namespace ID in subtree rooted at this node. |
 | `n_max` | [NamespaceID](#type-aliases) | Max namespace ID in subtree rooted at this node. |
-| `v`     | `byte[32]`                   | Node value.                                      |
+| `v`     | [HashDigest](#hashdigest)    | Node value.                                      |
 
 The base case (an empty tree) is defined as:
 ```C++
@@ -319,9 +319,9 @@ Additional rules are added on top of plain [binary Merkle trees](#binary-merkle-
 1. The number of hashing operations can be reduced to be logarithmic in the number of non-empty leaves on average, assuming a uniform distribution of non-empty leaf keys. An internal node that is the root of a subtree that contains exactly one non-empty leaf is replaced by that leaf's leaf node.
 
 Nodes contain a single field:
-| name | type       | description |
-| ---- | ---------- | ----------- |
-| `v`  | `byte[32]` | Node value. |
+| name | type                      | description |
+| ---- | ------------------------- | ----------- |
+| `v`  | [HashDigest](#hashdigest) | Node value. |
 
 The base case (an empty tree) is defined as the default value:
 ```C++

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -295,8 +295,8 @@ v = h(l, r) = h(0x01, l.n_min, l.n_max, l.v, r.n_min, r.n_max, r.v)
 | `key`           | `byte[32]`                       | Key (i.e. index) of the leaf.                                            |
 | `depth`         | `uint16`                         | Depth of the leaf node. The root node is at depth `0`. Must be `<= 256`. |
 | `siblingValues` | [HashDigest](#hashdigest)`[]`    | Sibling hash values.                                                     |
-| `siblingMins`   | [NamespaceID](#type-aliases)`[]` | Sibling min namespaceIDs.                                                |
-| `siblingMaxs`   | [NamespaceID](#type-aliases)`[]` | Sibling max namespaceIDs.                                                |
+| `siblingMins`   | [NamespaceID](#type-aliases)`[]` | Sibling min namespace IDs.                                               |
+| `siblingMaxes`  | [NamespaceID](#type-aliases)`[]` | Sibling max namespace IDs.                                               |
 | `leaf`          | `byte[]`                         | Leaf value.                                                              |
 
 ## Sparse Merkle Tree


### PR DESCRIPTION
- [x] Change binary Merkle tree to use scheme in [RFC 6962](https://tools.ietf.org/html/rfc6962), i.e. unbalanced tree.
- [x] Split up computing the root and Merkle proofs into different subsections
- [ ] Example diagrams. (#49)
- [x] Define zero tree base case.
- [x] Fix wording on leaf messages -> leaf data.
- [ ] Merkle multiproof format. (#48)
- [x] Remove the annotated Merkle tree abstraction since it isn't used elsewhere in the spec except for NMT. Define the domain separation prefixing for base Merkle trees.

Rendered:
- https://github.com/lazyledger/lazyledger-specs/blob/adlerjohn-merkle_tree_fixes/specs/data_structures.md