### PR TITLE
Use hash of empty string for base case for Merkle trees

### DIFF
--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -228,7 +228,7 @@ Merkle trees are used to authenticate various pieces of data across the LazyLedg
 
 ### Binary Merkle Tree
 
-Binary Merkle trees are constructed in the same fashion as described in [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962). Leaves are hashed once to get leaf node values and internal node values are the hash of the concatenation of their children (either leaf nodes or other internal nodes).
+Binary Merkle trees are constructed in the same fashion as described in [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962), except for using [a different hashing function](#hashing). Leaves are hashed once to get leaf node values and internal node values are the hash of the concatenation of their children (either leaf nodes or other internal nodes).
 
 Nodes contain a single field:
 | name | type                      | description |
@@ -250,7 +250,7 @@ For internal node `node` with children `l` and `r`:
 node.v = h(0x01, serialize(l), serialize(r))
 ```
 
-Note that rather than duplicating the last node if there are an odd number of nodes (the [Bitcoin design](https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/consensus/merkle.cpp#L9-L43)), trees are allowed to be imbalanced. In other words, the height of each leaf may be different. For an example, see Section 2.1.3 of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962).
+Note that rather than duplicating the last node if there are an odd number of nodes (the [Bitcoin design](https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/consensus/merkle.cpp#L9-L43)), trees are allowed to be imbalanced. In other words, the height of each leaf may be different. For an example, see Section 2.1.3 of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962#section-2.1.3).
 
 Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepended for leaf nodes while `0x01` is prepended for internal nodes. This avoids a second-preimage attack [where internal nodes are presented as leaves](https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack) trees with leaves at different heights.
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -235,9 +235,9 @@ Nodes contain a single field:
 | ---- | ------------------------- | ----------- |
 | `v`  | [HashDigest](#hashdigest) | Node value. |
 
-The base case (an empty tree) is defined as zero:
+The base case (an empty tree) is defined as the [hash](#hashing) of the empty string:
 ```C++
-node.v = 0x0000000000000000000000000000000000000000000000000000000000000000
+node.v = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
 ```
 
 For leaf node `node` of leaf data `d`:
@@ -278,7 +278,7 @@ The base case (an empty tree) is defined as:
 ```C++
 node.n_min = 0x0000000000000000000000000000000000000000000000000000000000000000
 node.n_max = 0x0000000000000000000000000000000000000000000000000000000000000000
-node.v = 0x0000000000000000000000000000000000000000000000000000000000000000
+node.v = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
 ```
 
 For leaf node `node` of data `d`:
@@ -328,9 +328,9 @@ Nodes contain a single field:
 | ---- | ------------------------- | ----------- |
 | `v`  | [HashDigest](#hashdigest) | Node value. |
 
-The base case (an empty tree) is defined as the default value:
+The base case (an empty tree) is defined as the [hash](#hashing) of the empty string:
 ```C++
-node.v = 0x0000000000000000000000000000000000000000000000000000000000000000
+node.v = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
 ```
 
 For leaf node `node` of leaf data `d` with key `k`:


### PR DESCRIPTION
- [x] Use `keccak256() = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470` for base case.
- [x] Clarify relationship with RFC-6962.