### PR TITLE
Add erasure code fraud proof specification

### DIFF
--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -435,7 +435,7 @@ If a malicious block producer incorrectly computes the 2D Reed-Solomon code for 
 | name       | type                                                         | description                                                                     |
 | ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
 | `root`     | [HashDigest](#hashdigest)                                    | The Merkle root of the offending row or column.                                 |
-| `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the row or column root in `availableDataRoot`[#header].     |
+| `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the row or column root in [`availableDataRoot`](#header).   |
 | `axis`     | `bool`                                                       | A boolean indicating if it is an offending row or column; false if it is a row. |
 | `position` | `uint64`                                                     | The index of the row or column in the square.                                   |
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -427,17 +427,18 @@ If a malicious block producer incorrectly computes the 2D Reed-Solomon code for 
 | ---------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
 | `share`    | [Share](#share)                                              | The share.                                                                                      |
 | `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the share in [`availableDataRoot`](#header).                                |
-| `isCol`     | `bool`                                                       | A Boolean indicating if the proof is from a row root or column root; `false` if it is a row root. |
+| `isCol`    | `bool`                                                       | A Boolean indicating if the proof is from a row root or column root; `false` if it is a row root. |
 | `position` | `uint64`                                                     | The index of the share in the offending row or column.                                          |
 
 #### BadEncodingFraudProof
 
-| name       | type                                                         | description                                                                     |
-| ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
-| `root`     | [HashDigest](#hashdigest)                                    | The Merkle root of the offending row or column.                                 |
-| `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the row or column root in [`availableDataRoot`](#header).   |
-| `isCol`     | `bool`                                                       | A Boolean indicating if it is an offending row or column; `false` if it is a row. |
-| `position` | `uint64`                                                     | The index of the row or column in the square.                                   |
+| name          | type                                                         | description                                                                     |
+| ------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `shareProofs` | [ShareProof](#shareproof)`[]`                                | The available shares in the offending row or column.                            |
+| `root`        | [HashDigest](#hashdigest)                                    | The Merkle root of the offending row or column.                                 |
+| `proof`       | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the row or column root in [`availableDataRoot`](#header).   |
+| `isCol`       | `bool`                                                       | A Boolean indicating if it is an offending row or column; `false` if it is a row. |
+| `position`    | `uint64`                                                     | The index of the row or column in the square.                                   |
 
 ### Share
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -427,7 +427,7 @@ If a malicious block producer incorrectly computes the 2D Reed-Solomon code for 
 | ---------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
 | `share`    | [Share](#share)                                              | The share.                                                                                      |
 | `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the share in [`availableDataRoot`](#header).                                |
-| `axis`     | `bool`                                                       | A boolean indicating if the proof is from a row root or column root; false if it is a row root. |
+| `axis`     | `bool`                                                       | A Boolean indicating if the proof is from a row root or column root; `false` if it is a row root. |
 | `position` | `uint64`                                                     | The index of the share in the offending row or column.                                          |
 
 #### BadEncodingFraudProof

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -29,6 +29,8 @@ Data Structures
   - [Reed-Solomon Erasure Coding](#reed-solomon-erasure-coding)
   - [2D Reed-Solomon Encoding Scheme](#2d-reed-solomon-encoding-scheme)
   - [Invalid Erasure Coding](#invalid-erasure-coding)
+    - [ShareProof](#shareproof)
+    - [BadEncodingFraudProof](#badencodingfraudproof)
   - [Share](#share)
     - [Share Serialization](#share-serialization)
   - [Arranging Available Data Into Shares](#arranging-available-data-into-shares)

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -28,6 +28,7 @@ Data Structures
 - [Erasure Coding](#erasure-coding)
   - [Reed-Solomon Erasure Coding](#reed-solomon-erasure-coding)
   - [2D Reed-Solomon Encoding Scheme](#2d-reed-solomon-encoding-scheme)
+  - [Invalid Erasure Coding](#invalid-erasure-coding)
   - [Share](#share)
     - [Share Serialization](#share-serialization)
   - [Arranging Available Data Into Shares](#arranging-available-data-into-shares)
@@ -415,6 +416,28 @@ Now that all four quadrants of the `2k * 2k` matrix are filled, the row and colu
 Finally, the `availableDataRoot` of the block [Header](#header) is computed as the Merkle root of the [binary Merkle tree](#binary-merkle-tree) with the row and column roots as leaves.
 
 ![fig: Available data root.](./figures/data_root.svg)
+
+### Invalid Erasure Coding
+
+If a malicious block producer incorrectly computes the 2D Reed-Solomon code for a block's data, a fraud proof for this can be presented.
+
+#### ShareProof
+
+| name       | type                                                         | description                                                                                     |
+| ---------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `share`    | [Share](#share)                                              | The share.                                                                                      |
+| `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the share in `availableDataRoot`[#header].                                  |
+| `axis`     | `bool`                                                       | A boolean indicating if the proof is from a row root or column root; false if it is a row root. |
+| `position` | `uint64`                                                     | The index of the share in the offending row or column.                                          |
+
+#### BadEncodingFraudProof
+
+| name       | type                                                         | description                                                                     |
+| ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `root`     | [HashDigest](#hashdigest)                                    | The Merkle root of the offending row or column.                                 |
+| `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the row or column root in `availableDataRoot`[#header].     |
+| `axis`     | `bool`                                                       | A boolean indicating if it is an offending row or column; false if it is a row. |
+| `position` | `uint64`                                                     | The index of the row or column in the square.                                   |
 
 ### Share
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -427,7 +427,7 @@ If a malicious block producer incorrectly computes the 2D Reed-Solomon code for 
 | ---------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
 | `share`    | [Share](#share)                                              | The share.                                                                                      |
 | `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the share in [`availableDataRoot`](#header).                                |
-| `axis`     | `bool`                                                       | A Boolean indicating if the proof is from a row root or column root; `false` if it is a row root. |
+| `isCol`     | `bool`                                                       | A Boolean indicating if the proof is from a row root or column root; `false` if it is a row root. |
 | `position` | `uint64`                                                     | The index of the share in the offending row or column.                                          |
 
 #### BadEncodingFraudProof
@@ -436,7 +436,7 @@ If a malicious block producer incorrectly computes the 2D Reed-Solomon code for 
 | ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
 | `root`     | [HashDigest](#hashdigest)                                    | The Merkle root of the offending row or column.                                 |
 | `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the row or column root in [`availableDataRoot`](#header).   |
-| `axis`     | `bool`                                                       | A Boolean indicating if it is an offending row or column; `false` if it is a row. |
+| `isCol`     | `bool`                                                       | A Boolean indicating if it is an offending row or column; `false` if it is a row. |
 | `position` | `uint64`                                                     | The index of the row or column in the square.                                   |
 
 ### Share

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -436,7 +436,7 @@ If a malicious block producer incorrectly computes the 2D Reed-Solomon code for 
 | ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
 | `root`     | [HashDigest](#hashdigest)                                    | The Merkle root of the offending row or column.                                 |
 | `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the row or column root in [`availableDataRoot`](#header).   |
-| `axis`     | `bool`                                                       | A boolean indicating if it is an offending row or column; false if it is a row. |
+| `axis`     | `bool`                                                       | A Boolean indicating if it is an offending row or column; `false` if it is a row. |
 | `position` | `uint64`                                                     | The index of the row or column in the square.                                   |
 
 ### Share

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -426,7 +426,7 @@ If a malicious block producer incorrectly computes the 2D Reed-Solomon code for 
 | name       | type                                                         | description                                                                                     |
 | ---------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
 | `share`    | [Share](#share)                                              | The share.                                                                                      |
-| `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the share in `availableDataRoot`[#header].                                  |
+| `proof`    | [Namespace Merkle Tree Proof](#namespace-merkle-tree-proofs) | The Merkle proof of the share in [`availableDataRoot`](#header).                                |
 | `axis`     | `bool`                                                       | A boolean indicating if the proof is from a row root or column root; false if it is a row root. |
 | `position` | `uint64`                                                     | The index of the share in the offending row or column.                                          |
 


### PR DESCRIPTION
Closes https://github.com/lazyledger/lazyledger-specs/issues/63

Based on section 5.5 in https://arxiv.org/pdf/1809.09044.pdf.

rendered: https://github.com/lazyledger/lazyledger-specs/blob/rsmt2d-fraudproof/specs/data_structures.md#invalid-erasure-coding