### PR TITLE
Use previous message namespace ID for padding shares

### DIFF
--- a/rationale/message_block_layout.md
+++ b/rationale/message_block_layout.md
@@ -46,4 +46,4 @@ The last piece of the puzzle is determining _which_ row the message is placed at
 
 ### Caveats
 
-The message placement rules described above conflict with the first rule that shares must be ordered by namespace ID, as shares between two messages that are not placed adjacent to each other do not have a natural namespace they belong to. This is resolved by having [special transactions](./../specs/data_structures.md#signedtransactiondatapayforpadding) the block producer includes that specify a range a zero-padding shares for a given namespace ID (which must be between the namespace IDs of the surrounding real shares, inclusive).
+The message placement rules described above conflict with the first rule that shares must be ordered by namespace ID, as shares between two messages that are not placed adjacent to each other do not have a natural namespace they belong to. This is resolved by requiring that such shares have a value of zero and a namespace ID equal to the preceding message's. Since their value is known, they can be omitted from NMT proofs of all shares of a given namespace ID.

--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -20,7 +20,6 @@ Consensus Rules
     - [`block.availableData.transactionData`](#blockavailabledatatransactiondata)
         - [SignedTransactionDataTransfer](#signedtransactiondatatransfer)
         - [SignedTransactionDataPayForMessage](#signedtransactiondatapayformessage)
-        - [SignedTransactionDataPayForPadding](#signedtransactiondatapayforpadding)
         - [SignedTransactionDataCreateValidator](#signedtransactiondatacreatevalidator)
         - [SignedTransactionDataBeginUnbondingValidator](#signedtransactiondatabeginunbondingvalidator)
         - [SignedTransactionDataUnbondValidator](#signedtransactiondataunbondvalidator)
@@ -209,17 +208,6 @@ Apply the following to the state:
 
 ```
 state.accounts[sender].nonce += 1
-```
-
-#### SignedTransactionDataPayForPadding
-
-1. `tx.type` == [`TransactionType.PayForPadding`](./data_structures.md#signedtransactiondata).
-1. The `ceil(tx.messageSize / SHARE_SIZE)` shares starting at index `wrappedTransactions.messageStartIndex` must:
-    1. Have namespace ID `tx.messageNamespaceID`.
-
-Apply the following to the state:
-
-```
 ```
 
 #### SignedTransactionDataCreateValidator

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -40,7 +40,6 @@ Data Structures
     - [SignedTransactionData](#signedtransactiondata)
       - [SignedTransactionDataTransfer](#signedtransactiondatatransfer)
       - [SignedTransactionDataPayForMessage](#signedtransactiondatapayformessage)
-      - [SignedTransactionDataPayForPadding](#signedtransactiondatapayforpadding)
       - [SignedTransactionDataCreateValidator](#signedtransactiondatacreatevalidator)
       - [SignedTransactionDataBeginUnbondingValidator](#signedtransactiondatabeginunbondingvalidator)
       - [SignedTransactionDataUnbondValidator](#signedtransactiondataunbondvalidator)
@@ -540,21 +539,19 @@ Wrapped transactions include additional metadata by the block proposer that is c
 enum TransactionType : uint8_t {
     Transfer = 1,
     PayForMessage = 2,
-    PayForPadding = 3,
-    CreateValidator = 4,
-    BeginUnbondingValidator = 5,
-    UnbondValidator = 6,
-    CreateDelegation = 7,
-    BeginUnbondingDelegation = 8,
-    UnbondDelegation = 9,
-    Burn = 10,
+    CreateValidator = 3,
+    BeginUnbondingValidator = 4,
+    UnbondValidator = 5,
+    CreateDelegation = 6,
+    BeginUnbondingDelegation = 7,
+    UnbondDelegation = 8,
+    Burn = 9,
 };
 ```
 
 Signed transaction data comes in a number of types:
 1. [Transfer](#signedtransactiondatatransfer)
 1. [PayForMessage](#signedtransactiondatapayformessage)
-1. [PayForPadding](#signedtransactiondatapayforpadding)
 1. [CreateValidator](#signedtransactiondatacreatevalidator)
 1. [BeginUnbondingValidator](#signedtransactiondatabeginunbondingvalidator)
 1. [UnbondValidator](#signedtransactiondataunbondvalidator)
@@ -599,16 +596,6 @@ Transfers `amount` coins to `to`.
 Pays for the inclusion of a [message](#message) in the same block.
 
 The commitment to message shares `messageShareCommitment` is a [Merkle root](#binary-merkle-tree) of message share roots. Each message share root is [a subtree root in a row NMT](#arranging-available-data-into-shares). For rationale, see [rationale doc](../rationale/message_block_layout.md).
-
-##### SignedTransactionDataPayForPadding
-
-| name                 | type                           | description                                                  |
-| -------------------- | ------------------------------ | ------------------------------------------------------------ |
-| `type`               | `TransactionType`              | Must be `TransactionType.PayForPadding`.                     |
-| `messageNamespaceID` | [`NamespaceID`](#type-aliases) | Namespace ID of padding this transaction pays a fee for.     |
-| `messageSize`        | `uint64`                       | Size of padding this transaction pays a fee for, in `byte`s. |
-
-Pays for the inclusion of a padding shares in the same block. Padding shares are used between real messages that are not tightly packed. For rationale, see [rationale doc](../rationale/message_block_layout.md).
 
 ##### SignedTransactionDataCreateValidator
 


### PR DESCRIPTION
And remove special tx to pay for padding.