### PR TITLE
Add delegation rewards and commission

### DIFF
--- a/rationale/distributing_rewards.md
+++ b/rationale/distributing_rewards.md
@@ -19,7 +19,7 @@ This forms the primary motivation of the scheme discussed here: a mechanism for 
 
 The scheme presented here is an incarnation of Cosmos' [F1 fee distribution scheme](https://github.com/cosmos/cosmos-sdk/blob/master/docs/spec/fee_distribution/f1_fee_distr.pdf). F1 has the nice property of being approximation-free and, with proper implementation details, can be highly efficient with state usage and completely iteration-free in all cases.
 
-Naively, when considering a single block, the reward that should be given to a delegator with stake $x$, who's delegating to a validator with total voting power $n$, whose reward in that block is $T$, is:
+Naively, when considering a single block, the reward that should be given to a delegator with stake $x$, who is delegating to a validator with total voting power $n$, whose reward in that block is $T$, is:
 
 $$
 \text{naive reward} = x \frac{T}{n}
@@ -35,6 +35,8 @@ Entry_f = \begin{cases}
     Entry_{f-1} + \frac{T_f}{n_f} & f > 0 \\
 \end{cases}
 $$
+
+Note that $Entry$ is a monotonically increasing function.
 
 Finally, the raw reward for a delegation is simply proportional to the difference in entries between the period where undelegation ended ($f$) and where it began ($k$).
 

--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -393,9 +393,6 @@ state.accounts[sender].status = AccountStatus.ValidatorUnbonded
 
 state.accounts[sender].balance += validator.stakedBalance
 
-validator.votingPower -= validator.stakedBalance
-validator.stakedBalance = 0
-
 state.inactiveValidatorSet[sender] = validator
 
 if validator.delegatedCount == 0

--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -544,9 +544,10 @@ state.accounts[sender].nonce += 1
 state.accounts[sender].balance -= totalCost(0, bytesPaid)
 state.accounts[sender].status = None
 
+# Return the delegated stake
 state.accounts[sender].balance += delegation.stakedBalance
-postCommissionRewards = validator.commissionRate * delegation.stakedBalance * (delegation.endEntry - delegation.beginEntry)
-state.accounts[sender].balance += postCommissionRewards
+# Also disperse rewards (commission has already been levied)
+state.accounts[sender].balance += delegation.stakedBalance * (delegation.endEntry - delegation.beginEntry)
 
 if state.accounts[delegation.validator].status == AccountStatus.ValidatorQueued ||
       state.accounts[delegation.validator].status == AccountStatus.ValidatorUnbonding
@@ -616,8 +617,9 @@ else if account.status == AccountStatus.ValidatorBonded
     proposer = state.activeValidatorSet[block.header.proposerAddress]
 
 blockReward = state.activeValidatorSet.proposerBlockReward
-proposer.commissionRewards += proposer.commission * blockReward
-proposer.pendingRewards += blockReward
+commissionReward = proposer.commission * blockReward
+proposer.commissionRewards += commissionReward
+proposer.pendingRewards += blockReward - commissionReward
 
 # Even though the voting power hasn't changed yet, we consider this a period change.
 # Note: this isn't perfect because the block reward is shared with delegations

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -64,6 +64,7 @@ Data Structures
   - [Validator](#validator)
   - [ActiveValidatorCount](#activevalidatorcount)
   - [ActiveVotingPower](#activevotingpower)
+  - [ProposerBlockReward](#proposerblockreward)
   - [ValidatorQueueHead](#validatorqueuehead)
   - [PeriodEntry](#periodentry)
   - [Decimal](#decimal)
@@ -830,18 +831,18 @@ In the delegation subtree, delegations are keyed by the [hash](#hashdigest) of t
 
 ### Validator
 
-| name              | type                         | description                                                                            |
-| ----------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
-| `stakedBalance`   | [VotingPower](#type-aliases) | Validator's personal staked balance, in `4u`.                                          |
-| `commissionRate`  | [Decimal](#decimal)          | Commission rate.                                                                       |
-| `delegatedCount`  | `uint32`                     | Number of accounts delegating to this validator.                                       |
-| `votingPower`     | [VotingPower](#type-aliases) | Total voting power as staked balance + delegated stake, in `4u`.                       |
-| `pendingRewards`  | [Amount](#type-aliases)      | Rewards collected so far this period, in `1u`.                                         |
-| `latestEntry`     | [PeriodEntry](#periodentry)  | Latest entry, used for calculating reward distribution.                                |
-| `unbondingHeight` | [Height](#type-aliases)      | Block height validator began unbonding.                                                |
-| `isSlashed`       | `bool`                       | If this validator has been slashed or not.                                             |
-| `slashRate`       | [Decimal](#decimal)          | _Optional_, only if `isSlashed` is set. Rate at which this validator has been slashed. |
-| `next`            | [Address](#type-aliases)     | Next validator in the queue. Zero if this validator is not in the queue.               |
+| name                | type                         | description                                                                            |
+| ------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
+| `commissionRewards` | `uint64`                     | Validator's commission rewards, in `1u`.                                               |
+| `commissionRate`    | [Decimal](#decimal)          | Commission rate.                                                                       |
+| `delegatedCount`    | `uint32`                     | Number of accounts delegating to this validator.                                       |
+| `votingPower`       | [VotingPower](#type-aliases) | Total voting power as staked balance + delegated stake, in `4u`.                       |
+| `pendingRewards`    | [Amount](#type-aliases)      | Rewards collected so far this period, in `1u`.                                         |
+| `latestEntry`       | [PeriodEntry](#periodentry)  | Latest entry, used for calculating reward distribution.                                |
+| `unbondingHeight`   | [Height](#type-aliases)      | Block height validator began unbonding.                                                |
+| `isSlashed`         | `bool`                       | If this validator has been slashed or not.                                             |
+| `slashRate`         | [Decimal](#decimal)          | _Optional_, only if `isSlashed` is set. Rate at which this validator has been slashed. |
+| `next`              | [Address](#type-aliases)     | Next validator in the queue. Zero if this validator is not in the queue.               |
 
 Validator objects represent all the information needed to be keep track of a validator.
 
@@ -864,6 +865,14 @@ Since the [active validator set](#validator) is stored in a [Sparse Merkle Tree]
 | `votingPower` | `uint64` | Active voting power. |
 
 Since the [active validator set](#validator) is stored in a [Sparse Merkle Tree](#sparse-merkle-tree), there is no compact way of proving the active voting power. The active voting power is stored in the active validators subtree, and is keyed with `1` (i.e. `0x0000000000000000000000000000000000000000000000000000000000000001`), with the first byte replaced with `ACTIVE_VALIDATORS_SUBTREE_ID`.
+
+### ProposerBlockReward
+
+| name     | type     | description                                                                    |
+| -------- | -------- | ------------------------------------------------------------------------------ |
+| `reward` | `uint64` | Total block reward (subsidy + fees) in current block so far. Reset each block. |
+
+The current block reward for the proposer is kept track of here. This is keyed with `2` (i.e. `0x0000000000000000000000000000000000000000000000000000000000000002`), with the first byte replaced with `ACTIVE_VALIDATORS_SUBTREE_ID`.
 
 ### ValidatorQueueHead
 


### PR DESCRIPTION
Fixes #95, #104.

Major changes:
* Remove `stakedBalance` for validators. Validators now have no balance and need to delegate to themselves. This can be abstracted away at the UI layer.
* Delegation commission is computed and rewards (both block subsidy and fees) are dispersed to both validators and delegations. Commission rewards are stored in a new field in the validator object.

Currently validator commission rewards simply sit there until the validator unbonds. We should support delegating this reward #117.