### PR TITLE
Support delegation of commission and rewards without withdrawals

### DIFF
--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -611,6 +611,8 @@ state.activeValidatorSet[block.header.proposerAddress] = proposer
 
 #### End Block
 
+Apply the following to the state:
+
 ```py
 account = state.accounts[block.header.proposerAddress]
 

--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -354,6 +354,7 @@ if state.accounts[sender].status == AccountStatus.ValidatorQueued
 else if state.accounts[sender].status == AccountStatus.ValidatorBonded
     validator = state.activeValidatorSet[sender]
     delete state.activeValidatorSet[sender]
+
 validator.unbondingHeight = block.height + 1
 validator.latestEntry += validator.pendingRewards // validator.votingPower
 validator.pendingRewards = 0
@@ -634,9 +635,6 @@ proposer.pendingRewards += blockReward - commissionReward
 # Even though the voting power hasn't changed yet, we consider this a period change.
 proposer.latestEntry += proposer.pendingRewards // state.activeValidatorSet.proposerInitialVotingPower
 proposer.pendingRewards = 0
-
-proposer.votingPower += blockReward
-state.activeValidatorSet.activeVotingPower += blockReward
 
 if account.status == AccountStatus.ValidatorUnbonding
       account.status == AccountStatus.ValidatorUnbonded

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -65,6 +65,7 @@ Data Structures
   - [ActiveValidatorCount](#activevalidatorcount)
   - [ActiveVotingPower](#activevotingpower)
   - [ProposerBlockReward](#proposerblockreward)
+  - [ProposerInitialVotingPower](#proposerinitialvotingpower)
   - [ValidatorQueueHead](#validatorqueuehead)
   - [PeriodEntry](#periodentry)
   - [Decimal](#decimal)
@@ -873,6 +874,14 @@ Since the [active validator set](#validator) is stored in a [Sparse Merkle Tree]
 | `reward` | `uint64` | Total block reward (subsidy + fees) in current block so far. Reset each block. |
 
 The current block reward for the proposer is kept track of here. This is keyed with `2` (i.e. `0x0000000000000000000000000000000000000000000000000000000000000002`), with the first byte replaced with `ACTIVE_VALIDATORS_SUBTREE_ID`.
+
+### ProposerInitialVotingPower
+
+| name          | type     | description                                                                    |
+| ------------- | -------- | ------------------------------------------------------------------------------ |
+| `votingPower` | `uint64` | Total block reward (subsidy + fees) in current block so far. Reset each block. |
+
+The proposer's voting power at the beginning of the block is kept track of here. This is keyed with `3` (i.e. `0x0000000000000000000000000000000000000000000000000000000000000003`), with the first byte replaced with `ACTIVE_VALIDATORS_SUBTREE_ID`.
 
 ### ValidatorQueueHead
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -49,6 +49,8 @@ Data Structures
       - [SignedTransactionDataBeginUnbondingDelegation](#signedtransactiondatabeginunbondingdelegation)
       - [SignedTransactionDataUnbondDelegation](#signedtransactiondataunbonddelegation)
       - [SignedTransactionDataBurn](#signedtransactiondataburn)
+      - [SignedTransactionRedelegateCommission](#signedtransactionredelegatecommission)
+      - [SignedTransactionRedelegateReward](#signedtransactionredelegatereward)
   - [IntermediateStateRootData](#intermediatestaterootdata)
     - [WrappedIntermediateStateRoot](#wrappedintermediatestateroot)
     - [IntermediateStateRoot](#intermediatestateroot)
@@ -570,6 +572,8 @@ enum TransactionType : uint8_t {
     BeginUnbondingDelegation = 7,
     UnbondDelegation = 8,
     Burn = 9,
+    RedelegateCommission = 10,
+    RedelegateReward = 11,
 };
 ```
 
@@ -583,6 +587,8 @@ Signed transaction data comes in a number of types:
 1. [BeginUnbondingDelegation](#signedtransactiondatabeginunbondingdelegation)
 1. [UnbondDelegation](#signedtransactiondataunbonddelegation)
 1. [Burn](#signedtransactiondataburn)
+1. [RedelegateCommission](#signedtransactionredelegatecommission)
+1. [RedelegateReward](#signedtransactionredelegatereward)
 
 Common fields are denoted here to avoid repeating descriptions:
 
@@ -694,6 +700,27 @@ Finish unbonding the [Delegation](#delegation) at this address.
 | `fee`      | [TransactionFee](#transactionfee) |                                              |
 | `nonce`    | [Nonce](#type-aliases)            |                                              |
 | `graffiti` | [Graffiti](#type-aliases)         | Graffiti to indicate the reason for burning. |
+
+##### SignedTransactionRedelegateCommission
+
+| name    | type                              | description                                     |
+| ------- | --------------------------------- | ----------------------------------------------- |
+| `type`  | `TransactionType`                 | Must be `TransactionType.RedelegateCommission`. |
+| `to`    | [Address](#address)               |                                                 |
+| `fee`   | [TransactionFee](#transactionfee) |                                                 |
+| `nonce` | [Nonce](#type-aliases)            |                                                 |
+
+Assigns validator's pending commission to a delegation.
+
+##### SignedTransactionRedelegateReward
+
+| name    | type                              | description                                 |
+| ------- | --------------------------------- | ------------------------------------------- |
+| `type`  | `TransactionType`                 | Must be `TransactionType.RedelegateReward`. |
+| `fee`   | [TransactionFee](#transactionfee) |                                             |
+| `nonce` | [Nonce](#type-aliases)            |                                             |
+
+Adds delegation's pending rewards to voting power.
 
 ### IntermediateStateRootData
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -904,9 +904,9 @@ The current block reward for the proposer is kept track of here. This is keyed w
 
 ### ProposerInitialVotingPower
 
-| name          | type     | description                                                                    |
-| ------------- | -------- | ------------------------------------------------------------------------------ |
-| `votingPower` | `uint64` | Total block reward (subsidy + fees) in current block so far. Reset each block. |
+| name          | type     | description                                                              |
+| ------------- | -------- | ------------------------------------------------------------------------ |
+| `votingPower` | `uint64` | Voting power of the proposer at the start of each block. Set each block. |
 
 The proposer's voting power at the beginning of the block is kept track of here. This is keyed with `3` (i.e. `0x0000000000000000000000000000000000000000000000000000000000000003`), with the first byte replaced with `ACTIVE_VALIDATORS_SUBTREE_ID`.
 


### PR DESCRIPTION
Fixes #117.

* Tangential: Fix block reward to be distributed based on voting power at beginning of block, not end.
* Add two new tx types to "redelegate" pending rewards (for delegations) and pending commission rewards (for validators). Relegating requires moving all pending coins and computes new F1 entries since voting power changes.