### PR TITLE
Add PayForMessage networking rationale

### DIFF
--- a/specs/networking.md
+++ b/specs/networking.md
@@ -4,6 +4,7 @@ Networking
 - [Wire Format](#wire-format)
     - [AvailableData](#availabledata)
     - [AvailableDataRow](#availabledatarow)
+    - [WireTxPayForMessage](#wiretxpayformessage)
 
 ## Wire Format
 
@@ -18,3 +19,13 @@ Networking
 | name     | type                                    | description      |
 | -------- | --------------------------------------- | ---------------- |
 | `shares` | [Share](./data_structures.md#share)`[]` | Shares in a row. |
+
+### WireTxPayForMessage
+
+Defined as `WireTxPayForMessage` as a [wire type](./proto/wire.proto).
+
+Accepting a `WireTxPayForMessage` into the mempool requires different logic than other transactions in LazyLedger, since it leverages the paradigm of block proposers being able to malleate transaction data. Unlike [SignedTransactionDataPayForMessage](./data_structures.md#signedtransactiondatapayformessage) (the canonical data type that is included in blocks and committed to with a data root in the block header), each `WireTxPayForMessage` (the over-the-wire representation of the same) has potentially multiple signatures.
+
+Transaction senders who want to pay for a message will create a [SignedTransactionDataPayForMessage](./data_structures.md#signedtransactiondatapayformessage) object, `stx`, filling in the `stx.messageShareCommitment` field [based on the non-interactive default rules](../rationale/message_block_layout.md#non-interactive-default-rules) for `k = AVAILABLE_DATA_ORIGINAL_SQUARE_MAX`, then signing it to get a [transaction](./data_structures.md#transaction) `tx`. This process is repeated with successively smaller `k`s, decreasing by powers of 2 until `k * k <= stx.messageSize`. At that point, there would be insufficient shares to include both the message and transaction. Using the rest of the signed transaction data along with the pairs of `(tx.signedTransactionData.messageShareCommitment, tx.signature)`, a `WireTxPayForMessage` object is constructed.
+
+Receiving a `WireTxPayForMessage` object from the network follows the reverse process: for each `message_commitment_and_signature`, verify using the [based on the non-interactive default rules](../rationale/message_block_layout.md#non-interactive-default-rules) that the signature is valid.

--- a/specs/proto/wire.proto
+++ b/specs/proto/wire.proto
@@ -11,6 +11,7 @@ message TransactionFee {
 }
 
 message Decimal {
+  // https://github.com/lazyledger/lazyledger-specs/issues/120
   uint64 todo = 1;
 }
 

--- a/specs/proto/wire.proto
+++ b/specs/proto/wire.proto
@@ -15,11 +15,13 @@ message Decimal {
 }
 
 message MessageCommitmentAndSignature {
+  // Original square size the share commitment was computed for
+  uint64 k = 1;
   // 32-byte hash: commitment to message shares
-  bytes share_commitment = 1;
+  bytes share_commitment = 2;
   // 64-byte signature a single SignedTransactionPayForMessage
   // https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#signedtransactiondatapayformessage
-  bytes signature = 2;
+  bytes signature = 3;
 }
 
 message WireTxTransfer {

--- a/specs/proto/wire.proto
+++ b/specs/proto/wire.proto
@@ -1,0 +1,95 @@
+syntax = "proto3";
+
+// Define wire messages for transaction types.
+// https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#signedtransactiondata
+
+message TransactionFee {
+  // Max base fee rate (burnt)
+  uint64 base_rate_max = 1;
+  // Max tip fee rate (rewarded to block proposer)
+  uint64 tip_rate_max = 2;
+}
+
+message Decimal {
+  uint64 todo = 1;
+}
+
+message MessageCommitmentAndSignature {
+  // 32-byte hash: commitment to message shares
+  bytes share_commitment = 1;
+  // 64-byte signature a single SignedTransactionPayForMessage
+  // https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#signedtransactiondatapayformessage
+  bytes signature = 2;
+}
+
+message WireTxTransfer {
+  uint64 amount = 1;
+  // 32-byte address
+  bytes to = 2;
+  TransactionFee fee = 3;
+  uint64 nonce = 4;
+}
+
+message WireTxPayForMessage {
+  TransactionFee fee = 1;
+  uint64 nonce = 2;
+  // 8-byte namespace ID
+  bytes message_namespace_id = 3;
+  uint64 message_size = 4;
+  bytes message = 5;
+  repeated MessageCommitmentAndSignature message_commitment_and_signature = 6;
+}
+
+message WireTxCreateValidator {
+  TransactionFee fee = 1;
+  uint64 nonce = 2;
+  Decimal commission_rate = 3;
+}
+
+message WireTxBeginUnbondingValidator {
+  TransactionFee fee = 1;
+  uint64 nonce = 2;
+}
+
+message WireTxUnbondValidator {
+  TransactionFee fee = 1;
+  uint64 nonce = 2;
+}
+
+message WireTxCreateDelegation {
+  uint64 amount = 1;
+  // 32-byte address
+  bytes to = 2;
+  TransactionFee fee = 3;
+  uint64 nonce = 4;
+}
+
+message WireTxBeginUnbondingDelegation {
+  TransactionFee fee = 1;
+  uint64 nonce = 2;
+}
+
+message WireTxUnbondDelegation {
+  TransactionFee fee = 1;
+  uint64 nonce = 2;
+}
+
+message WireTxBurn {
+  uint64 amount = 1;
+  TransactionFee fee = 2;
+  uint64 nonce = 3;
+  // 32-byte graffiti
+  bytes graffiti = 4;
+}
+
+message WireTxRedelegateCommission {
+  // 32-byte address
+  bytes to = 1;
+  TransactionFee fee = 2;
+  uint64 nonce = 3;
+}
+
+message WireTxRedelegateReward {
+  TransactionFee fee = 1;
+  uint64 nonce = 2;
+}


### PR DESCRIPTION
Add explanation for the networking logic of `PayForMessage` transaction types.