### PR TITLE
Define non-integer type

### DIFF
--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -722,7 +722,7 @@ proposer.latestEntry += proposer.pendingRewards // proposer.votingPower
 proposer.pendingRewards = 0
 
 blockReward = state.activeValidatorSet.proposerBlockReward
-commissionReward = proposer.commission * blockReward
+commissionReward = proposer.commissionRate * blockReward
 proposer.commissionRewards += commissionReward
 proposer.pendingRewards += blockReward - commissionReward
 

--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -303,7 +303,8 @@ The following checks must be `true`:
 1. `tx.fee.tipRateMax` >= `block.header.feeHeader.tipRate`.
 1. `totalCost(0, bytesPaid)` <= `state.accounts[sender].balance`.
 1. `tx.nonce` == `state.accounts[sender].nonce + 1`.
-1. `tx.commissionRate` <!--TODO check some bounds here-->
+1. `tx.commissionRate.denominator > 0`.
+1. `tx.commissionRate.numerator <= tx.commissionRate.denominator`.
 1. `state.accounts[sender].status` == `AccountStatus.None`.
 
 Apply the following to the state:

--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -722,7 +722,7 @@ proposer.latestEntry += proposer.pendingRewards // proposer.votingPower
 proposer.pendingRewards = 0
 
 blockReward = state.activeValidatorSet.proposerBlockReward
-commissionReward = proposer.commissionRate * blockReward
+commissionReward = proposer.commissionRate.numerator * blockReward // proposer.commissionRate.denominator
 proposer.commissionRewards += commissionReward
 proposer.pendingRewards += blockReward - commissionReward
 

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -930,7 +930,12 @@ For explanation on entries, see the [reward distribution rationale document](../
 
 ### Decimal
 
-TODO define a format for numbers in the range `[0,1]`
+| name          | type   | description           |
+| ------------- | ------ | --------------------- |
+| `numerator`   | uint64 | Rational numerator.   |
+| `denominator` | uint64 | Rational denominator. |
+
+Represents a (potentially) non-integer number.
 
 ## Consensus Parameters
 


### PR DESCRIPTION
Fixes #120.

Defines the Decimal non-integer type as a rational number.