### PR TITLE
Define consensus messages

### DIFF
--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -125,7 +125,7 @@ The [block header](./data_structures.md#header) `block.header` (`header` for sho
 
 1. `header.height` == `prev.header.height + 1`.
 1. `header.timestamp` > `prev.header.timestamp`.
-1. `header.lastBlockID` == the [block ID](./data_structures.md#blockid) of `prev`.
+1. `header.lastHeaderHash` == the [header hash](./data_structures.md#header) of `prev`.
 1. `header.lastCommitHash` == the [hash](./data_structures.md#hashing) of `lastCommit`.
 1. `header.consensusRoot` == the value computed [here](./data_structures.md#consensus-parameters).
 1. `header.feeHeader.baseRate` == `prev.header.feeHeader.baseRate * floor(1 + (prev.header.availableDataOriginalSharesUsed - AVAILABLE_DATA_ORIGINAL_SQUARE_TARGET) / (BASE_FEE_CHANGE_RATE * AVAILABLE_DATA_ORIGINAL_SQUARE_TARGET))`.
@@ -148,7 +148,7 @@ The last [commit](./data_structures.md#commit) `block.lastCommit` (`lastCommit` 
 
 1. `lastCommit.height` == `prev.header.height`.
 1. `lastCommit.round` >= `1`.
-1. `lastCommit.blockID` == the [block ID](./data_structures.md#blockid) of `prev`.
+1. `lastCommit.headerHash` == the [header hash](./data_structures.md#header) of `prev`.
 1. Length of `lastCommit.signatures` <= [`MAX_VALIDATORS`](#constants).
 1. Each of `lastCommit.signatures` must be a valid [CommitSig](./data_structures.md#commitsig)
 1. The sum of the votes for `prev` in `lastCommit` must be at least 2/3 (rounded up) of the voting power of `prev`'s next validator set.

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -10,7 +10,6 @@ Data Structures
   - [AvailableData](#availabledata)
   - [Commit](#commit)
   - [Timestamp](#timestamp)
-  - [BlockID](#blockid)
   - [HashDigest](#hashdigest)
   - [FeeHeader](#feeheader)
   - [TransactionFee](#transactionfee)
@@ -83,7 +82,6 @@ Data Structures
 | --------------------------- | -------------------------- |
 | [`Address`](#address)       | `byte[32]`                 |
 | `Amount`                    | `uint64`                   |
-| [`BlockID`](#blockid)       | [HashDigest](#hashdigest)  |
 | `Graffiti`                  | `byte[MAX_GRAFFITI_BYTES]` |
 | [`HashDigest`](#hashdigest) | `byte[32]`                 |
 | `Height`                    | `uint64`                   |
@@ -115,7 +113,7 @@ Block header, which is fully downloaded by both full clients and light clients.
 | --------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `height`                          | [Height](#type-aliases)   | Block height. The genesis block is at height `1`.                                                                                                                  |
 | `timestamp`                       | [Timestamp](#timestamp)   | Timestamp of this block.                                                                                                                                           |
-| `lastBlockID`                     | [BlockID](#blockid)       | Previous block's ID.                                                                                                                                               |
+| `lastHeaderHash`                  | [HashDigest](#hashdigest) | Previous block's header hash.                                                                                                                                      |
 | `lastCommitHash`                  | [HashDigest](#hashdigest) | Previous block's Tendermint commit hash.                                                                                                                           |
 | `consensusRoot`                   | [HashDigest](#hashdigest) | Merkle root of [consensus parameters](#consensus-parameters) for this block.                                                                                       |
 | `feeHeader`                       | [FeeHeader](#feeheader)   | Header data pertaining to fees.                                                                                                                                    |
@@ -125,6 +123,8 @@ Block header, which is fully downloaded by both full clients and light clients.
 | `proposerAddress`                 | [Address](#address)       | Address of this block's proposer.                                                                                                                                  |
 
 The size of the [original data square](#arranging-available-data-into-shares), `availableDataOriginalSquareSize`, isn't explicitly declared in the block header. Instead, it is implicitly computed as the smallest power of 2 whose square is at least `availableDataOriginalSharesUsed` (in other words, the smallest power of 4 that is at least `availableDataOriginalSharesUsed`).
+
+The header hash is the [hash](#hashing) of the [serialized](#serialization) header.
 
 ### AvailableDataHeader
 
@@ -156,7 +156,7 @@ Data that is [erasure-coded](#erasure-coding) for [data availability checks](htt
 | ------------ | --------------------------- | ---------------------------------- |
 | `height`     | [Height](#type-aliases)     | Block height.                      |
 | `round`      | [Round](#type-aliases)      | Round. Incremented on view change. |
-| `blockID`    | [BlockID](#blockid)         | Block ID of the previous block.    |
+| `headerHash` | [HashDigest](#hashdigest)   | Header hash of the previous block. |
 | `signatures` | [CommitSig](#commitsig)`[]` | List of signatures.                |
 
 ### Timestamp
@@ -164,12 +164,6 @@ Data that is [erasure-coded](#erasure-coding) for [data availability checks](htt
 Timestamp is a [type alias](#type-aliases).
 
 LazyLedger uses a 64-bit unsigned integer (`uint64`) to represent time in [TAI64](http://cr.yp.to/libtai/tai64.html) format.
-
-### BlockID
-
-BlockID is a [type alias](#type-aliases).
-
-The block ID is a single Merkle root: the root of the [block header](#header)'s fields, in the order provided in the spec. The root is computed using a [binary Merkle tree](#binary-merkle-tree).
 
 ### HashDigest
 
@@ -204,16 +198,16 @@ Addresses are the [hash](#hashing) [digest](#hashdigest) of the [public key](#pu
 ### CommitSig
 
 ```C++
-enum BlockIDFlag : uint8_t {
-    BlockIDFlagAbsent = 1,
-    BlockIDFlagCommit = 2,
-    BlockIDFlagNil = 3,
+enum CommitFlag : uint8_t {
+    CommitFlagAbsent = 1,
+    CommitFlagCommit = 2,
+    CommitFlagNil = 3,
 };
 ```
 
 | name               | type                    | description |
 | ------------------ | ----------------------- | ----------- |
-| `blockIDFlag`      | `BlockIDFlag`           |             |
+| `commitFlag`       | `CommitFlag`            |             |
 | `validatorAddress` | [Address](#address)     |             |
 | `timestamp`        | [Timestamp](#timestamp) |             |
 | `signature`        | [Signature](#signature) |             |
@@ -772,16 +766,16 @@ enum VoteType : uint8_t {
 };
 ```
 
-| name               | type                    | description |
-| ------------------ | ----------------------- | ----------- |
-| `type`             | `VoteType`              |             |
-| `height`           | [Height](#type-aliases) |             |
-| `round`            | [Round](#type-aliases)  |             |
-| `blockID`          | [BlockID](#blockid)     |             |
-| `timestamp`        | [Timestamp](#timestamp) |             |
-| `validatorAddress` | [Address](#address)     |             |
-| `validatorIndex`   | `uint64`                |             |
-| `signature`        | [Signature](#signature) |             |
+| name               | type                      | description |
+| ------------------ | ------------------------- | ----------- |
+| `type`             | `VoteType`                |             |
+| `height`           | [Height](#type-aliases)   |             |
+| `round`            | [Round](#type-aliases)    |             |
+| `headerHash`       | [HashDigest](#hashdigest) |             |
+| `timestamp`        | [Timestamp](#timestamp)   |             |
+| `validatorAddress` | [Address](#address)       |             |
+| `validatorIndex`   | `uint64`                  |             |
+| `signature`        | [Signature](#signature)   |             |
 
 ### MessageData
 

--- a/specs/figures/block_data_structures.dot
+++ b/specs/figures/block_data_structures.dot
@@ -27,7 +27,7 @@ digraph G {
 
         subgraph cluster_header {
             label = "header";
-            struct1 [label = "height | timestamp | lastBlockID | <f3> lastCommitHash | consensusRoot | <f5> feeHeader | stateCommitment | availableDataOriginalSharesUsed | <f8> availableDataRoot | proposerAddress"];
+            struct1 [label = "height | timestamp | headerHash | <f3> lastCommitHash | consensusRoot | <f5> feeHeader | stateCommitment | availableDataOriginalSharesUsed | <f8> availableDataRoot | proposerAddress"];
         }
     }
 

--- a/specs/figures/block_data_structures.svg
+++ b/specs/figures/block_data_structures.svg
@@ -93,7 +93,7 @@
 <polyline fill="none" stroke="#000000" points="24,-248.2 229.693,-248.2 "/>
 <text text-anchor="middle" x="126.8465" y="-231.6" font-family="Times,serif" font-size="14.00" fill="#000000">timestamp</text>
 <polyline fill="none" stroke="#000000" points="24,-223.4 229.693,-223.4 "/>
-<text text-anchor="middle" x="126.8465" y="-206.8" font-family="Times,serif" font-size="14.00" fill="#000000">lastBlockID</text>
+<text text-anchor="middle" x="126.8465" y="-206.8" font-family="Times,serif" font-size="14.00" fill="#000000">lastHeaderHash</text>
 <polyline fill="none" stroke="#000000" points="24,-198.6 229.693,-198.6 "/>
 <text text-anchor="middle" x="126.8465" y="-182" font-family="Times,serif" font-size="14.00" fill="#000000">lastCommitHash</text>
 <polyline fill="none" stroke="#000000" points="24,-173.8 229.693,-173.8 "/>

--- a/specs/proto/consensus.proto
+++ b/specs/proto/consensus.proto
@@ -4,16 +4,16 @@ syntax = "proto3";
 
 // https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#feeheader
 message FeeHeader {
-  uint64 baseRate = 1;
-  uint64 tipRate = 2;
+  uint64 base_rate = 1;
+  uint64 tip_rate = 2;
 }
 
 // https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#availabledataheader
 message AvailableDataHeader {
   // array of 32-byte hashes
-  repeated bytes rowRoots = 1;
+  repeated bytes row_roots = 1;
   // array of 32-byte hashes
-  repeated bytes colRoots = 2;
+  repeated bytes col_roots = 2;
 }
 
 message ConsensusProposal {
@@ -21,18 +21,18 @@ message ConsensusProposal {
   uint64 round = 2;
   uint64 timestamp = 3;
   // 32-byte hash
-  bytes lastHeaderHash = 4;
+  bytes last_header_hash = 4;
   // 32-byte hash
-  bytes lastCommitHash = 5;
+  bytes last_commit_hash = 5;
   // 32-byte hash
-  bytes consensusRoot = 6;
-  FeeHeader feeHeader = 7;
+  bytes consensus_root = 6;
+  FeeHeader fee_header = 7;
   // 32-byte hash
-  bytes stateCommitment = 8;
-  uint64 availableDataOriginalSharesUsed = 9;
-  AvailableDataHeader availableDataHeader = 10;
+  bytes state_commitment = 8;
+  uint64 available_data_original_shares_used = 9;
+  AvailableDataHeader available_data_header = 10;
   // 64-byte signature
-  bytes proposerSignature = 11;
+  bytes proposer_signature = 11;
 }
 
 enum CommitFlag {
@@ -43,11 +43,11 @@ enum CommitFlag {
 }
 
 message ConsensusVote {
-  CommitFlag commitFlag = 1;
+  CommitFlag commit_flag = 1;
   uint64 height = 2;
   uint64 round = 3;
   // 32-byte hash
-  bytes headerHash = 4;
+  bytes header_hash = 4;
   uint64 timestamp = 5;
   // 64-byte signature
   bytes signature = 6;

--- a/specs/proto/consensus.proto
+++ b/specs/proto/consensus.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+// Define wire types for consensus messages.
+
+// https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#feeheader
+message FeeHeader {
+  uint64 baseRate = 1;
+  uint64 tipRate = 2;
+}
+
+// https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#availabledataheader
+message AvailableDataHeader {
+  // array of 32-byte hashes
+  repeated bytes rowRoots = 1;
+  // array of 32-byte hashes
+  repeated bytes colRoots = 2;
+}
+
+message ConsensusProposal {
+  uint64 height = 1;
+  uint64 round = 2;
+  uint64 timestamp = 3;
+  // 32-byte hash
+  bytes lastBlockID = 4;
+  // 32-byte hash
+  bytes lastCommitHash = 5;
+  // 32-byte hash
+  bytes consensusRoot = 6;
+  FeeHeader feeHeader = 7;
+  // 32-byte hash
+  bytes stateCommitment = 8;
+  uint64 availableDataOriginalSharesUsed = 9;
+  AvailableDataHeader availableDataHeader = 10;
+  // 64-byte signature
+  bytes proposerSignature = 11;
+}
+
+enum BlockIDFlag {
+  BlockIDFlagAbsentNone = 0;
+  BlockIDFlagAbsent = 1;
+  BlockIDFlagCommit = 2;
+  BlockIDFlagNil = 3;
+}
+
+message ConsensusVote {
+  BlockIDFlag blockIDFlag = 1;
+  uint64 height = 2;
+  uint64 round = 3;
+  // 32-byte hash
+  bytes blockID = 4;
+  uint64 timestamp = 5;
+  // 64-byte signature
+  bytes signature = 6;
+}

--- a/specs/proto/consensus.proto
+++ b/specs/proto/consensus.proto
@@ -21,7 +21,7 @@ message ConsensusProposal {
   uint64 round = 2;
   uint64 timestamp = 3;
   // 32-byte hash
-  bytes lastBlockID = 4;
+  bytes lastHeaderHash = 4;
   // 32-byte hash
   bytes lastCommitHash = 5;
   // 32-byte hash
@@ -35,19 +35,19 @@ message ConsensusProposal {
   bytes proposerSignature = 11;
 }
 
-enum BlockIDFlag {
-  BlockIDFlagAbsentNone = 0;
-  BlockIDFlagAbsent = 1;
-  BlockIDFlagCommit = 2;
-  BlockIDFlagNil = 3;
+enum CommitFlag {
+  CommitFlagAbsentNone = 0;
+  CommitFlagAbsent = 1;
+  CommitFlagCommit = 2;
+  CommitFlagNil = 3;
 }
 
 message ConsensusVote {
-  BlockIDFlag blockIDFlag = 1;
+  CommitFlag commitFlag = 1;
   uint64 height = 2;
   uint64 round = 3;
   // 32-byte hash
-  bytes blockID = 4;
+  bytes headerHash = 4;
   uint64 timestamp = 5;
   // 64-byte signature
   bytes signature = 6;


### PR DESCRIPTION
Fixes #126.

- Define _proposals_ and _votes_.
- Rename block ID to header hash, and hash header instead of Merkleizing it ([ref](https://github.com/tendermint/spec/issues/175#issuecomment-701543731)).