### PR TITLE
Add linting and formatting guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@
 - [Networking](specs/networking.md)
 - [Light client](specs/light_client.md)
 - [Node types](specs/node_types.md)
+
+## Contributing
+
+Markdown files must conform to [GitHub Flavored Markdown](https://github.github.com/gfm/). Markdown must be formatted with:
+
+- [markdownlint](https://github.com/DavidAnson/markdownlint)
+- [Markdown Table Prettifier](https://github.com/darkriszty/MarkdownTablePrettify-VSCodeExt)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-LazyLedger Specifications
-===
+# LazyLedger Specifications
 
 [![Community](https://img.shields.io/badge/chat%20on-discord-orange?&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/YsnTPcSfWQ)
 

--- a/rationale/distributing_rewards.md
+++ b/rationale/distributing_rewards.md
@@ -1,5 +1,4 @@
-Rationale: Distributing Rewards and Penalties
-===
+# Rationale: Distributing Rewards and Penalties
 
 - [Preamble](#preamble)
 - [Distribution Scheme](#distribution-scheme)
@@ -8,6 +7,7 @@ Rationale: Distributing Rewards and Penalties
 ## Preamble
 
 Due to the requirement that all incorrect state transitions on LazyLedger be provable with a [compact fraud proof](https://arxiv.org/abs/1809.09044) that is cheap enough to verify within a smart contract on a remote chain (e.g. Ethereum), computing how rewards and penalties are distributed must involve no iterations. To understand why, let us consider the following desiderata in a staking system:
+
 1. In-protocol stake delegation: this makes it easier for users to participate in the consensus process, and reduces reliance on custodial staking services.
 1. In-protocol enforcement of proper distribution of rewards and penalities to delegators: rewards and penalties collected by validators should be distributed to delegators trustlessly.
 
@@ -27,7 +27,7 @@ $$
 
 In other words, the voting power contributed by the delegator multiplied by the _reward rate_, i.e. the rewards per unit of voting power. We note that if the total voting power of a validator remains constant forever, then the above equation holds and is approximation-free. However, changes to the total voting power need to be accounted for.
 
-Blocks between two changes to a validator's voting power (i.e. whenever a user delegates or undelegates stake) are a _period_. Every time a validator's voting power changes (i.e. a new period $f$ begins), an entry $Entry_f$ for this period is saved in state, which records _the reward rate up to the beginning of_ $f$. This is simply the sum of the reward rate up to the beginning of previous period $f-1$ and the reward rate of the period $f$ itself:
+Blocks between two changes to a validator's voting power (i.e. whenever a user delegates or undelegates stake) are a _period_. Every time a validator's voting power changes (i.e. a new period $f$ begins), an entry $Entry_f$ for this period is saved in state, which records_the reward rate up to the beginning of_ $f$. This is simply the sum of the reward rate up to the beginning of previous period $f-1$ and the reward rate of the period $f$ itself:
 
 $$
 Entry_f = \begin{cases}
@@ -49,6 +49,7 @@ This raw reward can be scaled by additional factors, such as commissions or slas
 ### State-Efficient Implementation
 
 The F1 paper does not specify where entries are stored in state, but the understanding is that they are placed in independent state elements. This has the downside of requiring multiple Merkle branches to prove the inclusion of entries for e.g. fraud proofs. We can improve on this by leveraging a specific property of entries, namely that each entry is only used in exactly two cases:
+
 1. To compute the next entry.
 1. To compute the reward of a delegator.
 

--- a/rationale/fees.md
+++ b/rationale/fees.md
@@ -1,5 +1,4 @@
-Fees
-===
+# Fees
 
 - [Preamble](#preamble)
 - [Background: EIP-1559](#background-eip-1559)
@@ -18,6 +17,7 @@ This document describes the rationale and structure of an elastic block size lim
 The essence of EIP-1559 is that, rather than the [first-price auction fee rate](https://arxiv.org/abs/1901.06830) of traditional cryptocurrencies, transactions under EIP-1559 define two fee rate parameters: a maximum base fee rate and a tip rate. The base fee is burned as a mechanism for enabling an elastic block size, and the tip is given to the miner of the block that includes the transaction (and is itself subject to a first-price auction). All transactions in a block burn the same base fee.
 
 The base fee grows if the previous block was more than half-full, and shrinks if the previous block was less than half full, by a parameter. We note, as above, that fee burning is simply a mechanism for making an elastic block size limit viable. This parameter should be chosen with the following in mind:
+
 1. The target (or, expected) block size should be bounded by the cost to run a full node assuming all blocks are at the target block size (also known as "decentralization").
 1. The maximum block size should bounded by the size of a "poison" block, i.e. one that would disrupt the consensus protocol.
 
@@ -26,6 +26,7 @@ From this, we see that there is nothing inherent in half-fullness, and indeed th
 ## Fee Burning
 
 The scheme described here is fundamentally identical to EIP-1559, save for the choice of parameters:
+
 1. Target block size: since blocks grow in size by a power of 4 due to the arrangement of data in a square, a reasonable initial choice would be 1:4 target:maximum block size limits.
 1. Rate of change: there is nothing inherently wrong (or especially right) with the $\frac{1}{8}$ rate of change prescribed by EIP-1559, so this parameter remains unchanged.
 

--- a/rationale/message_block_layout.md
+++ b/rationale/message_block_layout.md
@@ -1,5 +1,4 @@
-Message Layout
-===
+# Message Layout
 
 - [Preamble](#preamble)
 - [Message Layout Rationale](#message-layout-rationale)
@@ -17,6 +16,7 @@ Block data consists of transactions (which modify the LazyLedger chain's state),
 The simplest way we can imagine arranging block data is to simply serialize it all in no particular order, split it into fixed-sized shares, then arrange those shares into the `k * k` matrix in row-major order. However, this naive scheme can be improved in a number of ways, described below.
 
 First, we impose some ground rules:
+
 1. Data must be ordered by namespace ID. This makes queries into a NMT commitment of that data more efficient.
 1. Since non-message data are not naturally intended for particular namespaces, we assign reserved namespaces for them. A range of namespaces is reserved for this purpose, starting from the lowest possible namespace ID.
 1. By construction, the above two rules mean that non-message data always precedes message data in the row-major matrix, even when considering single rows or columns.
@@ -25,6 +25,7 @@ First, we impose some ground rules:
 Transactions can pay fees for a message to be included in the same block as the transaction itself. However, we do not want serialized transactions to include the entire message they pay for (which is the case in other blockchains with native execution, e.g. calldata in Ethereum transactions or OP_RETURN data in Bitcoin transactions), otherwise every node that validates the sanctity of the LazyLedger coin would need to download all message data. Transactions must therefore only include a commitment to (i.e. some hash of) the message they pay fees for. If implemented naively (e.g. with a simple hash of the message, or a simple binary Merkle tree root of the message), this can lead to a data availability problem, as there are no guarantees that the data behind these commitments is actually part of the block data.
 
 To that end, we impose some additional rules onto _messages only_: messages must be placed is a way such that both the transaction sender and the block producer can be held accountable—a necessary property for e.g. fee burning. Accountable in this context means that
+
 1. The transaction sender must pay sufficient fees for message inclusion.
 1. The block proposer cannot claim that a message was included when it was not (which implies that a transaction and the message it pays for must be included in the same block).
 
@@ -35,6 +36,7 @@ This, however, requires the block producer to interact with the transaction send
 ### Non-Interactive Default Rules
 
 As a non-consensus-critical default, we can impose some additional rules on message placement to make the possible starting locations of messages sufficiently predictable and constrained such that users can deterministically compute subtree roots without interaction:
+
 1. Messages that span multiple rows must begin at the start of a row (this can occur if a message is longer than `k` shares _or_ if the block producer decides to start a message partway through a row and it cannot fit).
 1. Messages begin at a location aligned with the largest power of 2 that is not larger than the message length or `k`.
 

--- a/rationale/rewards.md
+++ b/rationale/rewards.md
@@ -1,5 +1,4 @@
-Block Rewards
-===
+# Block Rewards
 
 Block rewards scale with the inverse square root of the total validating stake. This gives us a nice property: as the total validating stake decreases, returns per validator increases. This encourages additional validators to join and makes the system as a whole more robust even in the presence of secondary uses of the staking coin, e.g. being used as collateral in Decentralized Finance protocols.
 

--- a/rationale/rewards.md
+++ b/rationale/rewards.md
@@ -6,7 +6,7 @@ Note that non-constant reward scaling opens up the system to [gatekeeping attack
 
 The formula to calculate the reward per block uses the following symbols:
 | symbol | note                              |
-| ------ | --------------------------------- |
+|--------|-----------------------------------|
 | $R_B$  | Rewards per block, in coins.      |
 | $I_T$  | Target annual issuance, in coins. |
 | $t_B$  | Block time, in seconds.           |

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -6,7 +6,7 @@
 ## Common Terms and Expressions
 
 | name              | description                                                                                                                                                                      |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | App (application) | Alternate name for "[virtual sidechain](https://arxiv.org/abs/1905.09274)." LazyLedger apps are sidechains that post all their data onto the LazyLedger chain to share security. |
 | Transaction       | Request that modifies the consensus-critical state (validator balances and statuses).                                                                                            |
 | Message           | Request that is executed by a non-consensus-critical app.                                                                                                                        |

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -1,5 +1,4 @@
-Architecture
-===
+# Architecture
 
 - [Common Terms and Expressions](#common-terms-and-expressions)
 - [System Architecture](#system-architecture)

--- a/specs/block_proposer.md
+++ b/specs/block_proposer.md
@@ -1,5 +1,4 @@
-Honest Block Proposer
-===
+# Honest Block Proposer
 
 - [Deciding on a Block Size](#deciding-on-a-block-size)
 - [Laying out Transactions and Messages](#laying-out-transactions-and-messages)
@@ -11,10 +10,12 @@ This document describes the tasks of an honest block proposer to assemble a new 
 Before [arranging available data into shares](./data_structures.md#arranging-available-data-into-shares), the size of the original data's square must be determined.
 
 There are two restrictions on the original data's square size:
+
 1. It must be at most [`AVAILABLE_DATA_ORIGINAL_SQUARE_MAX`](./consensus.md#constants).
 1. It must be a power of 2.
 
 With these restrictions in mind, the block proposer performs the following actions:
+
 1. Collect as many transactions and messages from the mempool as possible, such that the total number of shares is at most [`AVAILABLE_DATA_ORIGINAL_SQUARE_MAX`](./consensus.md#constants).
 1. Compute the smallest square size that is a power of 2 that can fit the number of shares.
 1. Attempt to [lay out the collected transactions and messages](#laying-out-transactions-and-messages-in-a-block) in the current square.

--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -36,7 +36,7 @@
 ### Units
 
 | name | SI    | value   | description         |
-| ---- | ----- | ------- | ------------------- |
+|------|-------|---------|---------------------|
 | `1u` | `1u`  | `10**0` | `1` unit.           |
 | `2u` | `k1u` | `10**3` | `1000` units.       |
 | `3u` | `M1u` | `10**6` | `1000000` units.    |
@@ -45,7 +45,7 @@
 ### Constants
 
 | name                                    | type     | value   | unit    | description                                                                                                                                                         |
-| --------------------------------------- | -------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------------------------------------|----------|---------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `AVAILABLE_DATA_ORIGINAL_SQUARE_MAX`    | `uint64` |         | `share` | Maximum number of rows/columns of the original data [shares](data_structures.md#share) in [square layout](data_structures.md#arranging-available-data-into-shares). |
 | `AVAILABLE_DATA_ORIGINAL_SQUARE_TARGET` | `uint64` |         | `share` | Target number of rows/columns of the original data [shares](data_structures.md#share) in [square layout](data_structures.md#arranging-available-data-into-shares).  |
 | `BASE_FEE_CHANGE_RATE`                  | `uint64` | `8`     |         | Inverse of rate at which the [base fee](../rationale/fees.md) changes.                                                                                              |
@@ -65,7 +65,7 @@
 ### Reserved Namespace IDs
 
 | name                                    | type          | value                | description                                                                                |
-| --------------------------------------- | ------------- | -------------------- | ------------------------------------------------------------------------------------------ |
+|-----------------------------------------|---------------|----------------------|--------------------------------------------------------------------------------------------|
 | `TRANSACTION_NAMESPACE_ID`              | `NamespaceID` | `0x0000000000000001` | Transactions: requests that modify the state.                                              |
 | `INTERMEDIATE_STATE_ROOT_NAMESPACE_ID`  | `NamespaceID` | `0x0000000000000002` | Intermediate state roots, committed after every transaction.                               |
 | `EVIDENCE_NAMESPACE_ID`                 | `NamespaceID` | `0x0000000000000003` | Evidence: fraud proofs or other proof of slashable action.                                 |
@@ -76,7 +76,7 @@
 ### Reserved State Subtree IDs
 
 | name                             | type             | value  |
-| -------------------------------- | ---------------- | ------ |
+|----------------------------------|------------------|--------|
 | `ACCOUNTS_SUBTREE_ID`            | `StateSubtreeID` | `0x01` |
 | `ACTIVE_VALIDATORS_SUBTREE_ID`   | `StateSubtreeID` | `0x02` |
 | `INACTIVE_VALIDATORS_SUBTREE_ID` | `StateSubtreeID` | `0x03` |
@@ -86,7 +86,7 @@
 ### Rewards and Penalties
 
 | name                     | type     | value       | unit   | description                                             |
-| ------------------------ | -------- | ----------- | ------ | ------------------------------------------------------- |
+|--------------------------|----------|-------------|--------|---------------------------------------------------------|
 | `SECONDS_PER_YEAR`       | `uint64` | `31536000`  | second | Seconds per year. Omit leap seconds.                    |
 | `TARGET_ANNUAL_ISSUANCE` | `uint64` | `2 * 10**6` | `4u`   | `(= 2000000)` Target number of coins to issue per year. |
 

--- a/specs/consensus.md
+++ b/specs/consensus.md
@@ -1,36 +1,35 @@
-Consensus Rules
-===
+# Consensus Rules
 
 - [System Parameters](#system-parameters)
-    - [Units](#units)
-    - [Constants](#constants)
-    - [Reserved Namespace IDs](#reserved-namespace-ids)
-    - [Reserved State Subtree IDs](#reserved-state-subtree-ids)
-    - [Rewards and Penalties](#rewards-and-penalties)
+  - [Units](#units)
+  - [Constants](#constants)
+  - [Reserved Namespace IDs](#reserved-namespace-ids)
+  - [Reserved State Subtree IDs](#reserved-state-subtree-ids)
+  - [Rewards and Penalties](#rewards-and-penalties)
 - [Leader Selection](#leader-selection)
 - [Fork Choice](#fork-choice)
 - [Block Validity](#block-validity)
 - [Block Structure](#block-structure)
-    - [`block.header`](#blockheader)
-    - [`block.availableDataHeader`](#blockavailabledataheader)
-    - [`block.lastCommit`](#blocklastcommit)
-    - [`block.availableData`](#blockavailabledata)
+  - [`block.header`](#blockheader)
+  - [`block.availableDataHeader`](#blockavailabledataheader)
+  - [`block.lastCommit`](#blocklastcommit)
+  - [`block.availableData`](#blockavailabledata)
 - [State Transitions](#state-transitions)
-    - [`block.availableData.evidenceData`](#blockavailabledataevidencedata)
-    - [`block.availableData.transactionData`](#blockavailabledatatransactiondata)
-        - [SignedTransactionDataTransfer](#signedtransactiondatatransfer)
-        - [SignedTransactionDataPayForMessage](#signedtransactiondatapayformessage)
-        - [SignedTransactionDataCreateValidator](#signedtransactiondatacreatevalidator)
-        - [SignedTransactionDataBeginUnbondingValidator](#signedtransactiondatabeginunbondingvalidator)
-        - [SignedTransactionDataUnbondValidator](#signedtransactiondataunbondvalidator)
-        - [SignedTransactionDataCreateDelegation](#signedtransactiondatacreatedelegation)
-        - [SignedTransactionDataBeginUnbondingDelegation](#signedtransactiondatabeginunbondingdelegation)
-        - [SignedTransactionDataUnbondDelegation](#signedtransactiondataunbonddelegation)
-        - [SignedTransactionDataBurn](#signedtransactiondataburn)
-        - [SignedTransactionRedelegateCommission](#signedtransactionredelegatecommission)
-        - [SignedTransactionRedelegateReward](#signedtransactionredelegatereward)
-        - [Begin Block](#begin-block)
-        - [End Block](#end-block)
+  - [`block.availableData.evidenceData`](#blockavailabledataevidencedata)
+  - [`block.availableData.transactionData`](#blockavailabledatatransactiondata)
+    - [SignedTransactionDataTransfer](#signedtransactiondatatransfer)
+    - [SignedTransactionDataPayForMessage](#signedtransactiondatapayformessage)
+    - [SignedTransactionDataCreateValidator](#signedtransactiondatacreatevalidator)
+    - [SignedTransactionDataBeginUnbondingValidator](#signedtransactiondatabeginunbondingvalidator)
+    - [SignedTransactionDataUnbondValidator](#signedtransactiondataunbondvalidator)
+    - [SignedTransactionDataCreateDelegation](#signedtransactiondatacreatedelegation)
+    - [SignedTransactionDataBeginUnbondingDelegation](#signedtransactiondatabeginunbondingdelegation)
+    - [SignedTransactionDataUnbondDelegation](#signedtransactiondataunbonddelegation)
+    - [SignedTransactionDataBurn](#signedtransactiondataburn)
+    - [SignedTransactionRedelegateCommission](#signedtransactionredelegatecommission)
+    - [SignedTransactionRedelegateReward](#signedtransactionredelegatereward)
+    - [Begin Block](#begin-block)
+    - [End Block](#end-block)
 
 ## System Parameters
 
@@ -102,6 +101,7 @@ TODO
 ## Block Validity
 
 The validity of a newly-seen block, `block`, is determined by two components, detailed in subsequent sections:
+
 1. [Block structure](#block-structure): whether the block header is valid, and data in a block is arranged into a valid and matching data root (i.e. syntax).
 1. [State transition](#state-transitions): whether the application of transactions in the block produces a matching and valid state root (i.e. semantics).
 
@@ -112,6 +112,7 @@ Pseudocode in this section is not in any specific language and should be interpr
 Before executing [state transitions](#state-transitions), the structure of the [block](./data_structures.md#block) must be verified.
 
 The following block fields are acquired from the network and parsed (i.e. [deserialized](./data_structures.md#serialization)). If they cannot be parsed, the block is ignored but is not explicitly considered invalid by consensus rules. Further implications of ignoring a block are found in the [networking spec](./networking.md).
+
 1. [block.header](./data_structures.md#header)
 1. [block.availableDataHeader](./data_structures.md#availabledataheader)
 1. [block.lastCommit](./data_structures.md#commit)
@@ -170,6 +171,7 @@ Once the basic structure of the block [has been validated](#block-structure), st
 For this section, the variable `state` represents the [state tree](./data_structures.md#state), with `state.accounts[k]`, `state.inactiveValidatorSet[k]`, `state.activeValidatorSet[k]`, and `state.delegationSet[k]` being shorthand for the leaf in the state tree in the [accounts, inactive validator set, active validator set, and delegation set subtrees](./data_structures.md#state) with [pre-hashed key](./data_structures.md#state) `k`. E.g. `state.accounts[a]` is shorthand for `state[(ACCOUNTS_SUBTREE_ID << 8*(32-STATE_SUBTREE_RESERVED_BYTES)) | ((-1 >> 8*STATE_SUBTREE_RESERVED_BYTES) & hash(a))]`.
 
 State transitions are applied in the following order:
+
 1. [Begin block](#begin-block).
 1. [Evidence](#blockavailabledataevidencedata).
 1. [Transactions](#blockavailabledatatransactiondata).
@@ -193,17 +195,21 @@ For `wrappedTransaction`'s [transaction](./data_structures.md#transaction) `tran
 1. `transaction.signature` must be a [valid signature](./data_structures.md#public-key-cryptography) over `transaction.signedTransactionData`.
 
 Finally, each `wrappedTransaction` is processed depending on [its transaction type](./data_structures.md#signedtransactiondata). These are specified in the next subsections, where `tx` is short for `transaction.signedTransactionData`, and `sender` is the recovered signing [address](./data_structures.md#address). We will define a few helper functions:
+
 ```py
 baseCost(y) = block.header.feeHeader.baseRate * y
 tipCost(y) = block.header.feeHeader.tipRate * y
 totalCost(x, y) = x + baseCost(y) + tipCost(y)
 ```
+
 , where `x` above represents the amount of coins sent by the transaction authorizer and `y` above represents the a measure of the block space used by the transaction (i.e. size in bytes).
 
 Four additional helper functions are defined to manage the [validator queue](./data_structures.md#validator):
+
 1. `findFromQueue(power)`, which returns the address of the last validator in the [validator queue](./data_structures.md#validator) with voting power greater than or equal to `power`, or `0` if the queue is empty or no validators in the queue have at least `power` voting power.
 1. `parentFromQueue(address)`, which returns the address of the parent in the validator queue of the validator with address `address`, or `0` if `address` is not in the queue or is the head of the queue.
-3. `validatorQueueInsert`, defined as
+1. `validatorQueueInsert`, defined as
+
 ```py
 function validatorQueueInsert(validator)
     # Insert the new validator into the linked list
@@ -219,7 +225,10 @@ function validatorQueueInsert(validator)
         validator.next = state.validatorQueueHead
         state.validatorQueueHead = sender
 ```
+
+<!-- markdownlint-disable-next-line MD029 -->
 4. `validatorQueueRemove`, defined as
+
 ```py
 function validatorQueueRemove(validator, sender)
     # Remove existing validator from the linked list
@@ -239,9 +248,11 @@ function validatorQueueRemove(validator, sender)
 Note that light clients cannot perform a linear search through a linked list, and are instead provided logarithmic proofs (e.g. in the case of `parentFromQueue`, a proof to the parent is provided, which should have `address` as its next validator).
 
 In addition, three helper functions to manage the [message paid list](./data_structures.md#messagepaid):
+
 1. `findFromMessagePaidList(start)`, which returns the transaction ID of the last transaction in the [message paid list](./data_structures.md#messagepaid) with `finish` greater than `start`, or `0` if the list is empty or no transactions in the list have at least `start` `finish`.
 1. `parentFromMessagePaidList(txid)`, which returns the transaction ID of the parent in the message paid list of the transaction with ID `txid`, or `0` if `txid` is not in the list or is the head of the list.
-3. `messagePaidListInsert`, defined as
+1. `messagePaidListInsert`, defined as
+
 ```py
 function messagePaidListInsert(tx, txid)
     # Insert the new transaction into the linked list
@@ -258,6 +269,7 @@ function messagePaidListInsert(tx, txid)
 ```
 
 We define a helper function to compute [F1 entries](../rationale/distributing_rewards.md):
+
 ```py
 function compute_new_entry(reward, power)
     if power == 0

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -1,5 +1,4 @@
-Data Structures
-===
+# Data Structures
 
 - [Data Structures Overview](#data-structures-overview)
 - [Type Aliases](#type-aliases)
@@ -208,7 +207,7 @@ enum CommitFlag : uint8_t {
 ```
 
 | name               | type                    | description |
-| ------------------ | ----------------------- | ----------- |
+| ------------------ | ----------------------- | ------------|
 | `commitFlag`       | `CommitFlag`            |             |
 | `validatorAddress` | [Address](#address)     |             |
 | `timestamp`        | [Timestamp](#timestamp) |             |
@@ -228,6 +227,7 @@ Output of the [signing](#public-key-cryptography) process.
 Objects that are committed to or signed over require a canonical serialization. This is done using a deterministic (and thus, bijective) variant of protobuf defined [here](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-027-deterministic-protobuf-serialization.md).
 
 Note: there are two requirements for a serialization scheme, should this need to be changed:
+
 1. Must be bijective.
 1. Serialization must include the length of dynamic structures (e.g. arrays with variable length).
 
@@ -235,13 +235,13 @@ Note: there are two requirements for a serialization scheme, should this need to
 
 All protocol-level hashing is done using SHA-2-256 as defined in [FIPS 180-4](https://doi.org/10.6028/NIST.FIPS.180-4). SHA-2-256 outputs a digest that is 256 bits (i.e. 32 bytes) long.
 
-Libraries implementing SHA-2-256 are available in Go (https://pkg.go.dev/crypto/sha256) and Rust (https://docs.rs/sha2).
+Libraries implementing SHA-2-256 are available in Go (<https://pkg.go.dev/crypto/sha256>) and Rust (<https://docs.rs/sha2>).
 
 Unless otherwise indicated explicitly, objects are first [serialized](#serialization) before being hashed.
 
 ## Public-Key Cryptography
 
-Consensus-critical data is authenticated using [ECDSA](https://www.secg.org/sec1-v2.pdf), with the curve [secp256k1](https://en.bitcoin.it/wiki/Secp256k1). A highly-optimized library is available in C (https://github.com/bitcoin-core/secp256k1), with wrappers in Go (https://pkg.go.dev/github.com/ethereum/go-ethereum/crypto/secp256k1) and Rust (https://docs.rs/crate/secp256k1).
+Consensus-critical data is authenticated using [ECDSA](https://www.secg.org/sec1-v2.pdf), with the curve [secp256k1](https://en.bitcoin.it/wiki/Secp256k1). A highly-optimized library is available in C (<https://github.com/bitcoin-core/secp256k1>), with wrappers in Go (<https://pkg.go.dev/github.com/ethereum/go-ethereum/crypto/secp256k1>) and Rust (<https://docs.rs/crate/secp256k1>).
 
 [Public keys](#publickey) are encoded in uncompressed form, as the concatenation of the `x` and `y` values. No prefix is needed to distinguish between encoding schemes as this is the only encoding supported.
 
@@ -252,6 +252,8 @@ Deterministic signatures ([RFC-6979](https://tools.ietf.org/rfc/rfc6979.txt)) sh
 `v` represents the parity of the `Y` component of the point, `0` for even and `1` for odd. The `X` component of the point is assumed to always be low, since [the possibility of it being high is negligible](https://bitcoin.stackexchange.com/a/38909).
 
 Putting it all together, the encoding for signatures is:
+
+<!-- markdownlint-disable-next-line MD040 -->
 ```
 |    32 bytes   ||           32 bytes           |
 [256-bit r value][1-bit v value][255-bit s value]
@@ -273,16 +275,19 @@ Nodes contain a single field:
 | `v`  | [HashDigest](#hashdigest) | Node value. |
 
 The base case (an empty tree) is defined as the [hash](#hashing) of the empty string:
+
 ```C++
 node.v = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ```
 
 For leaf node `node` of leaf data `d`:
+
 ```C++
 node.v = h(0x00, serialize(d))
 ```
 
 For internal node `node` with children `l` and `r`:
+
 ```C++
 node.v = h(0x01, l.v, r.v)
 ```
@@ -311,6 +316,7 @@ Nodes contain three fields:
 | `v`     | [HashDigest](#hashdigest)    | Node value.                                      |
 
 The base case (an empty tree) is defined as:
+
 ```C++
 node.n_min = 0x0000000000000000
 node.n_max = 0x0000000000000000
@@ -318,6 +324,7 @@ node.v = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ```
 
 For leaf node `node` of [share](#share) data `d`:
+
 ```C++
 node.n_min = d.namespaceID
 node.n_max = d.namespaceID
@@ -329,6 +336,7 @@ The `namespaceID` message field here is the namespace ID of the leaf, which is a
 Leaves in an NMT **must** be lexicographically sorted by namespace ID in ascending order.
 
 For internal node `node` with children `l` and `r`:
+
 ```C++
 node.n_min = min(l.n_min, r.n_min)
 if l.n_min == PARITY_SHARE_NAMESPACE_ID
@@ -339,6 +347,7 @@ else
   node.n_max = max(l.n_max, r.n_max)
 node.v = h(0x01, l.n_min, l.n_max, l.v, r.l_min, r.l_max, r.v)
 ```
+
 Note that the above snippet leverages the property that leaves are sorted by namespace ID: if `l.n_min` is [`PARITY_SHARE_NAMESPACE_ID`](consensus.md#reserved-state-subtree-ids), so must `{l,r}.n_max`. By construction, either both the min and max namespace IDs of a node will be [`PARITY_SHARE_NAMESPACE_ID`](consensus.md#reserved-state-subtree-ids), or neither will: if `r.n_min` is [`PARITY_SHARE_NAMESPACE_ID`](consensus.md#reserved-state-subtree-ids), so must `r.n_max`.
 
 For some intuition: the min and max namespace IDs for subtree roots with at least one non-parity leaf (which includes the root of an NMT, as [the right half of an NMT as used in LazyLedger will be parity shares](#2d-reed-solomon-encoding-scheme)) _ignore_ the namespace ID for the parity leaves. Subtree roots with _only parity leaves_ have their min and max namespace ID set to [`PARITY_SHARE_NAMESPACE_ID`](consensus.md#reserved-state-subtree-ids). This allows for shorter proofs into the tree than if the namespace ID of parity shares was not ignored (which would cause the max namespace ID of the root to always be [`PARITY_SHARE_NAMESPACE_ID`](consensus.md#reserved-state-subtree-ids)).
@@ -360,6 +369,7 @@ When verifying an NMT proof, the root hash is checked by reconstructing the root
 Sparse Merkle Trees (SMTs) are _sparse_, i.e. they contain mostly empty leaves. They can be used as key-value stores for arbitrary data, as each leaf is keyed by its index in the tree. Storage efficiency is achieved through clever use of implicit defaults, avoiding the need to store empty leaves.
 
 Additional rules are added on top of plain [binary Merkle trees](#binary-merkle-tree):
+
 1. Default values are given to leaf nodes with empty leaves.
 1. While the above rule is sufficient to pre-compute the values of intermediate nodes that are roots of empty subtrees, a further simplification is to extend this default value to all nodes that are roots of empty subtrees. The 32-byte zero, i.e. `0x0000000000000000000000000000000000000000000000000000000000000000`, is used as the default value. This rule takes precedence over the above one.
 1. The number of hashing operations can be reduced to be logarithmic in the number of non-empty leaves on average, assuming a uniform distribution of non-empty leaf keys. An internal node that is the root of a subtree that contains exactly one non-empty leaf is replaced by that leaf's leaf node.
@@ -370,17 +380,21 @@ Nodes contain a single field:
 | `v`  | [HashDigest](#hashdigest) | Node value. |
 
 The base case (an empty tree) is defined as the [hash](#hashing) of the empty string:
+
 ```C++
 node.v = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ```
 
 For leaf node `node` of leaf data `d` with key `k`:
+
 ```C++
 node.v = h(0x00, k, h(serialize(d)))
 ```
+
 The key of leaf nodes must be prepended, since the index of a leaf node that is not at maximum depth cannot be determined without this information. Leaf values are hashed so that they do not need to be included in full in non-membership proofs.
 
 For internal node `node` with children `l` and `r`:
+
 ```C++
 node.v = h(0x01, l.v, r.v)
 ```
@@ -400,6 +414,7 @@ A proof into an SMT is structured as:
 | `includedSiblings` | `byte[32]`                    | Bitfield of explicitly included sibling hashes.                          |
 
 The `includedSiblings` is ordered by most-significant-byte first, with each byte ordered by most-significant-bit first. The lowest bit corresponds the leaf node level.
+
 ## Erasure Coding
 
 In order to enable trust-minimized light clients (i.e. light clients that do not rely on an honest majority of validating state assumption), it is critical that light clients can determine whether the data in each block is _available_ or not, without downloading the whole block itself. The technique used here was formally described in the paper [Fraud and Data Availability Proofs: Maximising Light Client Security and Scaling Blockchains with Dishonest Majorities](https://arxiv.org/abs/1809.09044).
@@ -411,6 +426,7 @@ The remainder of the subsections below specify the [2D Reed-Solomon erasure codi
 Note that while data is laid out in a two-dimensional square, rows and columns are erasure coded using a standard one-dimensional encoding.
 
 Reed-Solomon erasure coding is used as the underlying coding scheme. The parameters are:
+
 - 16-bit Galois field
 - [`availableDataOriginalSquareSize`](#header) original pieces (maximum of [`AVAILABLE_DATA_ORIGINAL_SQUARE_MAX`](./consensus.md#constants))
 - [`availableDataOriginalSquareSize`](#header) parity pieces (maximum of [`AVAILABLE_DATA_ORIGINAL_SQUARE_MAX`](./consensus.md#constants)) (i.e `availableDataOriginalSquareSize * 2` total pieces), for an erasure efficiency of 50%. In other words, any 50% of the pieces from the `availableDataOriginalSquareSize * 2` total pieces are enough to recover the original data.
@@ -427,6 +443,7 @@ The 2-dimensional data layout is described in this section. The roots of [NMTs](
 The data of `Q0` is the original data, and the remaining quadrants are parity data. Setting `k = availableDataOriginalSquareSize`, the original data first must be [split into shares](#share) and [arranged into a `k * k` matrix](#arranging-available-data-into-shares). Then the parity data can be computed.
 
 Where `A -> B` indicates that `B` is computed using [erasure coding](#reed-solomon-erasure-coding) from `A`:
+
 - `Q0 -> Q1` for each row in `Q0` and `Q1`
 - `Q0 -> Q2` for each column in `Q0` and `Q2`
 - `Q2 -> Q3` for each row in `Q2` and `Q3`
@@ -492,6 +509,7 @@ For non-parity shares, if there is insufficient request data to fill the share, 
 The previous sections described how some original data, arranged into a `k * k` matrix, can be extended into a `2k * 2k` matrix and committed to with NMT roots. This section specifies how [available data](#available-data) (which includes [transactions](#transactiondata), [intermediate state roots](#intermediatestaterootdata), [evidence](#evidencedata), and [messages](#messagedata)) is arranged into the matrix in the first place.
 
 Then,
+
 1. For each of `transactionData`, `intermediateStateRootData`, and `evidenceData`, [serialize](#serialization):
     1. For each request in the list:
         1. [Serialize](#serialization) the request (individually).
@@ -506,11 +524,13 @@ These shares are arranged in the [first quadrant](#2d-reed-solomon-encoding-sche
 ![fig: Original data: reserved.](./figures/rs2d_originaldata_reserved.svg)
 
 Each message in the list `messageData` is _independently_ serialized and split into `SHARE_SIZE`-byte shares. For each message, it is placed in the available data matrix, with row-major order, as follows:
+
 1. Place the first share of the message at the next unused location in the matrix, then place the remaining shares in the following locations.
 
 Transactions [must commit to a Merkle root of a list of hashes](#transaction) that are each guaranteed (assuming the block is valid) to be subtree roots in one or more of the row NMTs. For additional info, see [the rationale document](../rationale/message_block_layout.md) for this section.
 
 However, with only the rule above, interaction between the block producer and transaction sender may be required to compute a commitment to the message the transaction sender can sign over. To remove interaction, messages can optionally be laid out using a non-interactive default:
+
 1. Place the first share of the message at the next unused location in the matrix whose column in aligned with the largest power of 2 that is not larger than the message length or [`availableDataOriginalSquareSize`](#header), then place the remaining shares in the following locations **unless** there are insufficient unused locations in the row.
 1. If there are insufficient unused locations in the row, place the first share of the message at the first column of the next row. Then place the remaining shares in the following locations. By construction, any message whose length is greater than [`availableDataOriginalSquareSize`](#header) will be placed in this way.
 
@@ -564,6 +584,7 @@ enum TransactionType : uint8_t {
 ```
 
 Signed transaction data comes in a number of types:
+
 1. [Transfer](#signedtransactiondatatransfer)
 1. [PayForMessage](#signedtransactiondatapayformessage)
 1. [CreateValidator](#signedtransactiondatacreatevalidator)
@@ -789,6 +810,7 @@ The state of the LazyLedger chain is intentionally restricted to containing only
 The state tree is separated into `2**(8*STATE_SUBTREE_RESERVED_BYTES)` subtrees, each of which can be used to store a different component of the state. This is done by slicing off the highest `STATE_SUBTREE_RESERVED_BYTES` bytes from the key and replacing them with the appropriate [reserved state subtree ID](consensus.md#reserved-state-subtree-ids). Reducing the key size within subtrees also reduces the collision resistance of keys by `8*STATE_SUBTREE_RESERVED_BYTES` bits, but this is not an issue due the number of bits removed being small.
 
 A number of subtrees are maintained:
+
 1. [Accounts](#account)
 1. [Active validator set](#validator)
 1. [Inactive validator set](#validator)
@@ -818,10 +840,12 @@ enum AccountStatus : uint8_t {
 The `status` of an account indicates weather it is a validator (`AccountStatus.Validator*`), delegating to a validator (`AccountStatus.Delegation*`), or neither (`AccountStatus.None`). Being a validator and delegating are mutually exclusive, and only a single validator can be delegated to.
 
 Delegations have two statuses:
+
 1. `DelegationBonded`: This delegation is enabled for a `Queued` _or_ `Bonded` validator. Delegations to a `Queued` validator can be withdrawn immediately, while delegations for a `Bonded` validator must be unbonded first.
 1. `DelegationUnbonding`: This delegation is unbonding. It will remain in this status for at least `UNBONDING_DURATION` blocks, and while unbonding may still be slashed. Once the unbonding duration has expired, the delegation can be withdrawn.
 
 Validators have four statuses:
+
 1. `ValidatorQueued`: This validator has entered the queue to become an active validator. Once the next validator set transition occurs, if this validator has sufficient voting power (including its own stake and stake delegated to it) to be in the top `MAX_VALIDATORS` validators by voting power, it will become an active, i.e. `ValidatorBonded` validator. Until bonded, this validator can immediately exit the queue.
 1. `ValidatorBonded`: This validator is active and bonded. It can propose new blocks and vote on proposed blocks. Once bonded, an active validator must go through an unbonding process until its stake can be freed.
 1. `ValidatorUnbonding`: This validator is in the process of unbonding, which can be voluntary (the validator decided to stop being an active validator) or forced (the validator committed a slashable offence and was kicked from the active validator set). Validators will remain in this status for at least `UNBONDING_DURATION` blocks, and while unbonding may still be slashed.

--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -80,7 +80,7 @@
 ## Type Aliases
 
 | name                        | type                       |
-| --------------------------- | -------------------------- |
+|-----------------------------|----------------------------|
 | [`Address`](#address)       | `byte[32]`                 |
 | `Amount`                    | `uint64`                   |
 | `Graffiti`                  | `byte[MAX_GRAFFITI_BYTES]` |
@@ -100,7 +100,7 @@
 Blocks are the top-level data structure of the LazyLedger blockchain.
 
 | name                  | type                                        | description                                                           |
-| --------------------- | ------------------------------------------- | --------------------------------------------------------------------- |
+|-----------------------|---------------------------------------------|-----------------------------------------------------------------------|
 | `header`              | [Header](#header)                           | Block header. Contains primarily identification info and commitments. |
 | `availableDataHeader` | [AvailableDataHeader](#availabledataheader) | Header of available data. Contains commitments to erasure-coded data. |
 | `availableData`       | [AvailableData](#availabledata)             | Data that is erasure-coded for availability.                          |
@@ -111,7 +111,7 @@ Blocks are the top-level data structure of the LazyLedger blockchain.
 Block header, which is fully downloaded by both full clients and light clients.
 
 | name                              | type                      | description                                                                                                                                                        |
-| --------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|-----------------------------------|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `height`                          | [Height](#type-aliases)   | Block height. The genesis block is at height `1`.                                                                                                                  |
 | `timestamp`                       | [Timestamp](#timestamp)   | Timestamp of this block.                                                                                                                                           |
 | `lastHeaderHash`                  | [HashDigest](#hashdigest) | Previous block's header hash.                                                                                                                                      |
@@ -130,7 +130,7 @@ The header hash is the [hash](#hashing) of the [serialized](#serialization) head
 ### AvailableDataHeader
 
 | name       | type                          | description                            |
-| ---------- | ----------------------------- | -------------------------------------- |
+|------------|-------------------------------|----------------------------------------|
 | `rowRoots` | [HashDigest](#hashdigest)`[]` | Commitments to all erasure-coded data. |
 | `colRoots` | [HashDigest](#hashdigest)`[]` | Commitments to all erasure-coded data. |
 
@@ -145,7 +145,7 @@ The number of column roots is `availableDataOriginalSquareSize * 2`, and the num
 Data that is [erasure-coded](#erasure-coding) for [data availability checks](https://arxiv.org/abs/1809.09044).
 
 | name                        | type                                                    | description                                                                                                     |
-| --------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+|-----------------------------|---------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | `transactionData`           | [TransactionData](#transactiondata)                     | Transaction data. Transactions modify the validator set and balances, and pay fees for messages to be included. |
 | `intermediateStateRootData` | [IntermediateStateRootData](#intermediatestaterootdata) | Intermediate state roots used for fraud proofs.                                                                 |
 | `evidenceData`              | [EvidenceData](#evidencedata)                           | Evidence used for slashing conditions (e.g. equivocation).                                                      |
@@ -154,7 +154,7 @@ Data that is [erasure-coded](#erasure-coding) for [data availability checks](htt
 ### Commit
 
 | name         | type                        | description                        |
-| ------------ | --------------------------- | ---------------------------------- |
+|--------------|-----------------------------|------------------------------------|
 | `height`     | [Height](#type-aliases)     | Block height.                      |
 | `round`      | [Round](#type-aliases)      | Round. Incremented on view change. |
 | `headerHash` | [HashDigest](#hashdigest)   | Header hash of the previous block. |
@@ -175,7 +175,7 @@ Output of the [hashing](#hashing) function. Exactly 256 bits (32 bytes) long.
 ### FeeHeader
 
 | name       | type     | description                                      |
-| ---------- | -------- | ------------------------------------------------ |
+|------------|----------|--------------------------------------------------|
 | `baseRate` | `uint64` | The base fee rate for this block.                |
 | `tipRate`  | `uint64` | The tip rate for all transactions in this block. |
 
@@ -184,7 +184,7 @@ See the [rationale document](../rationale/fees.md) for more information on base 
 ### TransactionFee
 
 | name          | type     | description                                     |
-| ------------- | -------- | ----------------------------------------------- |
+|---------------|----------|-------------------------------------------------|
 | `baseRateMax` | `uint64` | The maximum base fee rate for this transaction. |
 | `tipRateMax`  | `uint64` | The maximum tip rate for this transaction.      |
 
@@ -207,7 +207,7 @@ enum CommitFlag : uint8_t {
 ```
 
 | name               | type                    | description |
-| ------------------ | ----------------------- | ------------|
+|--------------------|-------------------------|-------------|
 | `commitFlag`       | `CommitFlag`            |             |
 | `validatorAddress` | [Address](#address)     |             |
 | `timestamp`        | [Timestamp](#timestamp) |             |
@@ -216,7 +216,7 @@ enum CommitFlag : uint8_t {
 ### Signature
 
 | name | type       | description                                                          |
-| ---- | ---------- | -------------------------------------------------------------------- |
+|------|------------|----------------------------------------------------------------------|
 | `r`  | `byte[32]` | `r` value of the signature.                                          |
 | `vs` | `byte[32]` | 1-bit `v` value followed by last 255 bits of `s` value of signature. |
 
@@ -271,7 +271,7 @@ Binary Merkle trees are constructed in the same fashion as described in [Certifi
 
 Nodes contain a single field:
 | name | type                      | description |
-| ---- | ------------------------- | ----------- |
+|------|---------------------------|-------------|
 | `v`  | [HashDigest](#hashdigest) | Node value. |
 
 The base case (an empty tree) is defined as the [hash](#hashing) of the empty string:
@@ -299,7 +299,7 @@ Leaves and internal nodes are hashed differently: the one-byte `0x00` is prepend
 #### BinaryMerkleTreeInclusionProof
 
 | name       | type                          | description                                                     |
-| ---------- | ----------------------------- | --------------------------------------------------------------- |
+|------------|-------------------------------|-----------------------------------------------------------------|
 | `siblings` | [HashDigest](#hashdigest)`[]` | Sibling hash values, ordered starting from the leaf's neighbor. |
 
 A proof for a leaf in a [binary Merkle tree](#binary-merkle-tree), as per Section 2.1.1 of [Certificate Transparency (RFC-6962)](https://tools.ietf.org/html/rfc6962#section-2.1.1).
@@ -310,7 +310,7 @@ A proof for a leaf in a [binary Merkle tree](#binary-merkle-tree), as per Sectio
 
 Nodes contain three fields:
 | name    | type                         | description                                      |
-| ------- | ---------------------------- | ------------------------------------------------ |
+|---------|------------------------------|--------------------------------------------------|
 | `n_min` | [NamespaceID](#type-aliases) | Min namespace ID in subtree rooted at this node. |
 | `n_max` | [NamespaceID](#type-aliases) | Max namespace ID in subtree rooted at this node. |
 | `v`     | [HashDigest](#hashdigest)    | Node value.                                      |
@@ -357,7 +357,7 @@ A compact commitment can be computed by taking the [hash](#hashing) of the [seri
 #### NamespaceMerkleTreeInclusionProof
 
 | name            | type                             | description                                                     |
-| --------------- | -------------------------------- | --------------------------------------------------------------- |
+|-----------------|----------------------------------|-----------------------------------------------------------------|
 | `siblingValues` | [HashDigest](#hashdigest)`[]`    | Sibling hash values, ordered starting from the leaf's neighbor. |
 | `siblingMins`   | [NamespaceID](#type-aliases)`[]` | Sibling min namespace IDs.                                      |
 | `siblingMaxes`  | [NamespaceID](#type-aliases)`[]` | Sibling max namespace IDs.                                      |
@@ -376,7 +376,7 @@ Additional rules are added on top of plain [binary Merkle trees](#binary-merkle-
 
 Nodes contain a single field:
 | name | type                      | description |
-| ---- | ------------------------- | ----------- |
+|------|---------------------------|-------------|
 | `v`  | [HashDigest](#hashdigest) | Node value. |
 
 The base case (an empty tree) is defined as the [hash](#hashing) of the empty string:
@@ -408,7 +408,7 @@ For a Merkle branch of height `h`, an `h`-bit value is appended to the proof. Th
 A proof into an SMT is structured as:
 
 | name               | type                          | description                                                              |
-| ------------------ | ----------------------------- | ------------------------------------------------------------------------ |
+|--------------------|-------------------------------|--------------------------------------------------------------------------|
 | `depth`            | `uint16`                      | Depth of the leaf node. The root node is at depth `0`. Must be `<= 256`. |
 | `siblings`         | [HashDigest](#hashdigest)`[]` | Sibling hash values, ordered starting from the leaf's neighbor..         |
 | `includedSiblings` | `byte[32]`                    | Bitfield of explicitly included sibling hashes.                          |
@@ -469,7 +469,7 @@ If a malicious block producer incorrectly computes the 2D Reed-Solomon code for 
 #### ShareProof
 
 | name       | type                                                  | description                                                                                       |
-| ---------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+|------------|-------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | `share`    | [Share](#share)                                       | The share.                                                                                        |
 | `proof`    | [NamespaceMerkleTreeProof](#namespacemerkletreeproof) | The Merkle proof of the share in [`availableDataRoot`](#header).                                  |
 | `isCol`    | `bool`                                                | A Boolean indicating if the proof is from a row root or column root; `false` if it is a row root. |
@@ -478,7 +478,7 @@ If a malicious block producer incorrectly computes the 2D Reed-Solomon code for 
 #### BadEncodingFraudProof
 
 | name          | type                                                  | description                                                                       |
-| ------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
+|---------------|-------------------------------------------------------|-----------------------------------------------------------------------------------|
 | `shareProofs` | [ShareProof](#shareproof)`[]`                         | The available shares in the offending row or column.                              |
 | `root`        | [HashDigest](#hashdigest)                             | The Merkle root of the offending row or column.                                   |
 | `proof`       | [NamespaceMerkleTreeProof](#namespacemerkletreeproof) | The Merkle proof of the row or column root in [`availableDataRoot`](#header).     |
@@ -488,7 +488,7 @@ If a malicious block producer incorrectly computes the 2D Reed-Solomon code for 
 ### Share
 
 | name          | type                         | description                |
-| ------------- | ---------------------------- | -------------------------- |
+|---------------|------------------------------|----------------------------|
 | `namespaceID` | [NamespaceID](#type-aliases) | Namespace ID of the share. |
 | `rawData`     | `byte[SHARE_SIZE]`           | Raw share data.            |
 
@@ -545,7 +545,7 @@ The non-interactive default rules may introduce empty shares that do not belong 
 ### TransactionData
 
 | name                  | type                                          | description                   |
-| --------------------- | --------------------------------------------- | ----------------------------- |
+|-----------------------|-----------------------------------------------|-------------------------------|
 | `wrappedTransactions` | [WrappedTransaction](#wrappedtransaction)`[]` | List of wrapped transactions. |
 
 #### WrappedTransaction
@@ -553,7 +553,7 @@ The non-interactive default rules may introduce empty shares that do not belong 
 Wrapped transactions include additional metadata by the block proposer that is committed to in the [available data matrix](#arranging-available-data-into-shares).
 
 | name                | type                        | description                                                                                                                                                                                                                                                                                                |
-| ------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `index`             | `uint64`                    | Index of this transaction in the list of wrapped transactions. This information is lost when splitting transactions into [fixed-sized shares](#share), and needs to be re-added here for fraud proof support. Allows linking a transaction to an [intermediate state root](#wrappedintermediatestateroot). |
 | `transaction`       | [Transaction](#transaction) | Actual transaction.                                                                                                                                                                                                                                                                                        |
 | `messageStartIndex` | `uint64`                    | _Optional, only used if transaction pays for a message or padding_. Share index (in row-major order) of first share of message this transaction pays for. Needed for light verification of proper message inclusion.                                                                                       |
@@ -561,7 +561,7 @@ Wrapped transactions include additional metadata by the block proposer that is c
 #### Transaction
 
 | name                    | type                                            | description                       |
-| ----------------------- | ----------------------------------------------- | --------------------------------- |
+|-------------------------|-------------------------------------------------|-----------------------------------|
 | `signedTransactionData` | [SignedTransactionData](#signedtransactiondata) | Data payload that is signed over. |
 | `signature`             | [Signature](#signature)                         | Signature.                        |
 
@@ -600,7 +600,7 @@ Signed transaction data comes in a number of types:
 Common fields are denoted here to avoid repeating descriptions:
 
 | name     | type                              | description                                                                |
-| -------- | --------------------------------- | -------------------------------------------------------------------------- |
+|----------|-----------------------------------|----------------------------------------------------------------------------|
 | `type`   | `TransactionType`                 | Type of the transaction. Each type indicates a different state transition. |
 | `amount` | [Amount](#type-aliases)           | Amount of coins to send, in `1u`.                                          |
 | `to`     | [Address](#address)               | Recipient's address.                                                       |
@@ -610,7 +610,7 @@ Common fields are denoted here to avoid repeating descriptions:
 ##### SignedTransactionDataTransfer
 
 | name     | type                              | description                         |
-| -------- | --------------------------------- | ----------------------------------- |
+|----------|-----------------------------------|-------------------------------------|
 | `type`   | `TransactionType`                 | Must be `TransactionType.Transfer`. |
 | `amount` | [Amount](#type-aliases)           |                                     |
 | `to`     | [Address](#address)               |                                     |
@@ -622,7 +622,7 @@ Transfers `amount` coins to `to`.
 ##### SignedTransactionDataPayForMessage
 
 | name                     | type                              | description                                                  |
-| ------------------------ | --------------------------------- | ------------------------------------------------------------ |
+|--------------------------|-----------------------------------|--------------------------------------------------------------|
 | `type`                   | `TransactionType`                 | Must be `TransactionType.PayForMessage`.                     |
 | `fee`                    | [TransactionFee](#transactionfee) |                                                              |
 | `nonce`                  | [Nonce](#type-aliases)            |                                                              |
@@ -637,7 +637,7 @@ The commitment to message shares `messageShareCommitment` is a [Merkle root](#bi
 ##### SignedTransactionDataCreateValidator
 
 | name             | type                              | description                                |
-| ---------------- | --------------------------------- | ------------------------------------------ |
+|------------------|-----------------------------------|--------------------------------------------|
 | `type`           | `TransactionType`                 | Must be `TransactionType.CreateValidator`. |
 | `fee`            | [TransactionFee](#transactionfee) |                                            |
 | `nonce`          | [Nonce](#type-aliases)            |                                            |
@@ -648,7 +648,7 @@ Create a new [Validator](#validator) at this address.
 ##### SignedTransactionDataBeginUnbondingValidator
 
 | name    | type                              | description                                        |
-| ------- | --------------------------------- | -------------------------------------------------- |
+|---------|-----------------------------------|----------------------------------------------------|
 | `type`  | `TransactionType`                 | Must be `TransactionType.BeginUnbondingValidator`. |
 | `fee`   | [TransactionFee](#transactionfee) |                                                    |
 | `nonce` | [Nonce](#type-aliases)            |                                                    |
@@ -658,7 +658,7 @@ Begin unbonding the [Validator](#validator) at this address.
 ##### SignedTransactionDataUnbondValidator
 
 | name    | type                              | description                                |
-| ------- | --------------------------------- | ------------------------------------------ |
+|---------|-----------------------------------|--------------------------------------------|
 | `type`  | `TransactionType`                 | Must be `TransactionType.UnbondValidator`. |
 | `fee`   | [TransactionFee](#transactionfee) |                                            |
 | `nonce` | [Nonce](#type-aliases)            |                                            |
@@ -668,7 +668,7 @@ Finish unbonding the [Validator](#validator) at this address.
 ##### SignedTransactionDataCreateDelegation
 
 | name     | type                              | description                                 |
-| -------- | --------------------------------- | ------------------------------------------- |
+|----------|-----------------------------------|---------------------------------------------|
 | `type`   | `TransactionType`                 | Must be `TransactionType.CreateDelegation`. |
 | `amount` | [Amount](#type-aliases)           |                                             |
 | `to`     | [Address](#address)               |                                             |
@@ -680,7 +680,7 @@ Create a new [Delegation](#delegation) of `amount` coins worth of voting power f
 ##### SignedTransactionDataBeginUnbondingDelegation
 
 | name    | type                              | description                                         |
-| ------- | --------------------------------- | --------------------------------------------------- |
+|---------|-----------------------------------|-----------------------------------------------------|
 | `type`  | `TransactionType`                 | Must be `TransactionType.BeginUnbondingDelegation`. |
 | `fee`   | [TransactionFee](#transactionfee) |                                                     |
 | `nonce` | [Nonce](#type-aliases)            |                                                     |
@@ -690,7 +690,7 @@ Begin unbonding the [Delegation](#delegation) at this address.
 ##### SignedTransactionDataUnbondDelegation
 
 | name    | type                              | description                                 |
-| ------- | --------------------------------- | ------------------------------------------- |
+|---------|-----------------------------------|---------------------------------------------|
 | `type`  | `TransactionType`                 | Must be `TransactionType.UnbondDelegation`. |
 | `fee`   | [TransactionFee](#transactionfee) |                                             |
 | `nonce` | [Nonce](#type-aliases)            |                                             |
@@ -700,7 +700,7 @@ Finish unbonding the [Delegation](#delegation) at this address.
 ##### SignedTransactionDataBurn
 
 | name       | type                              | description                                  |
-| ---------- | --------------------------------- | -------------------------------------------- |
+|------------|-----------------------------------|----------------------------------------------|
 | `type`     | `TransactionType`                 | Must be `TransactionType.Burn`.              |
 | `amount`   | [Amount](#type-aliases)           |                                              |
 | `fee`      | [TransactionFee](#transactionfee) |                                              |
@@ -710,7 +710,7 @@ Finish unbonding the [Delegation](#delegation) at this address.
 ##### SignedTransactionRedelegateCommission
 
 | name    | type                              | description                                     |
-| ------- | --------------------------------- | ----------------------------------------------- |
+|---------|-----------------------------------|-------------------------------------------------|
 | `type`  | `TransactionType`                 | Must be `TransactionType.RedelegateCommission`. |
 | `to`    | [Address](#address)               |                                                 |
 | `fee`   | [TransactionFee](#transactionfee) |                                                 |
@@ -721,7 +721,7 @@ Assigns validator's pending commission to a delegation.
 ##### SignedTransactionRedelegateReward
 
 | name    | type                              | description                                 |
-| ------- | --------------------------------- | ------------------------------------------- |
+|---------|-----------------------------------|---------------------------------------------|
 | `type`  | `TransactionType`                 | Must be `TransactionType.RedelegateReward`. |
 | `fee`   | [TransactionFee](#transactionfee) |                                             |
 | `nonce` | [Nonce](#type-aliases)            |                                             |
@@ -731,20 +731,20 @@ Adds delegation's pending rewards to voting power.
 ### IntermediateStateRootData
 
 | name                            | type                                                              | description                               |
-| ------------------------------- | ----------------------------------------------------------------- | ----------------------------------------- |
+|---------------------------------|-------------------------------------------------------------------|-------------------------------------------|
 | `wrappedIntermediateStateRoots` | [WrappedIntermediateStateRoot](#wrappedintermediatestateroot)`[]` | List of wrapped intermediate state roots. |
 
 #### WrappedIntermediateStateRoot
 
 | name                    | type                                            | description                                                                                                                                                                                                                                                                                                                  |
-| ----------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------------------------|-------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `index`                 | `uint64`                                        | Index of this intermediate state root in the list of intermediate state roots. This information is lost when splitting intermediate state roots into [fixed-sized shares](#share), and needs to be re-added here for fraud proof support. Allows linking an intermediate state root to a [transaction](#wrappedtransaction). |
 | `intermediateStateRoot` | [IntermediateStateRoot](#intermediatestateroot) | Intermediate state root. Used for fraud proofs.                                                                                                                                                                                                                                                                              |
 
 #### IntermediateStateRoot
 
 | name   | type                      | description                                                                              |
-| ------ | ------------------------- | ---------------------------------------------------------------------------------------- |
+|--------|---------------------------|------------------------------------------------------------------------------------------|
 | `root` | [HashDigest](#hashdigest) | Root of intermediate state, which is composed of the global state and the validator set. |
 
 ### EvidenceData
@@ -752,13 +752,13 @@ Adds delegation's pending rewards to voting power.
 Wrapper for evidence data.
 
 | name        | type                      | description                                    |
-| ----------- | ------------------------- | ---------------------------------------------- |
+|-------------|---------------------------|------------------------------------------------|
 | `evidences` | [Evidence](#evidence)`[]` | List of evidence used for slashing conditions. |
 
 #### Evidence
 
 | name     | type                    | description |
-| -------- | ----------------------- | ----------- |
+|----------|-------------------------|-------------|
 | `pubKey` | [PublicKey](#publickey) |             |
 | `voteA`  | [Vote](#vote)           |             |
 | `voteB`  | [Vote](#vote)           |             |
@@ -766,7 +766,7 @@ Wrapper for evidence data.
 #### PublicKey
 
 | name | type       | description              |
-| ---- | ---------- | ------------------------ |
+|------|------------|--------------------------|
 | `x`  | `byte[32]` | `x` value of public key. |
 | `y`  | `byte[32]` | `y` value of public key. |
 
@@ -780,7 +780,7 @@ enum VoteType : uint8_t {
 ```
 
 | name               | type                      | description |
-| ------------------ | ------------------------- | ----------- |
+|--------------------|---------------------------|-------------|
 | `type`             | `VoteType`                |             |
 | `height`           | [Height](#type-aliases)   |             |
 | `round`            | [Round](#type-aliases)    |             |
@@ -793,13 +793,13 @@ enum VoteType : uint8_t {
 ### MessageData
 
 | name       | type                    | description       |
-| ---------- | ----------------------- | ----------------- |
+|------------|-------------------------|-------------------|
 | `messages` | [Message](#message)`[]` | List of messages. |
 
 #### Message
 
 | name          | type                         | description                   |
-| ------------- | ---------------------------- | ----------------------------- |
+|---------------|------------------------------|-------------------------------|
 | `namespaceID` | [NamespaceID](#type-aliases) | Namespace ID of this message. |
 | `rawData`     | `byte[]`                     | Raw message bytes.            |
 
@@ -832,7 +832,7 @@ enum AccountStatus : uint8_t {
 ```
 
 | name      | type                    | description                                                                       |
-| --------- | ----------------------- | --------------------------------------------------------------------------------- |
+|-----------|-------------------------|-----------------------------------------------------------------------------------|
 | `balance` | [Amount](#type-aliases) | Coin balance.                                                                     |
 | `nonce`   | [Nonce](#type-aliases)  | Account nonce. Every outgoing transaction from this account increments the nonce. |
 | `status`  | `AccountStatus`         | Validator or delegation status of this account.                                   |
@@ -856,7 +856,7 @@ In the accounts subtree, accounts (i.e. leaves) are keyed by the [hash](#hashdig
 ### Delegation
 
 | name              | type                         | description                                         |
-| ----------------- | ---------------------------- | --------------------------------------------------- |
+|-------------------|------------------------------|-----------------------------------------------------|
 | `validator`       | [Address](#address)          | The validator being delegating to.                  |
 | `stakedBalance`   | [VotingPower](#type-aliases) | Delegated stake, in `4u`.                           |
 | `beginEntry`      | [PeriodEntry](#periodentry)  | Entry when delegation began.                        |
@@ -870,7 +870,7 @@ In the delegation subtree, delegations are keyed by the [hash](#hashdigest) of t
 ### Validator
 
 | name                | type                         | description                                                                            |
-| ------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
+|---------------------|------------------------------|----------------------------------------------------------------------------------------|
 | `commissionRewards` | `uint64`                     | Validator's commission rewards, in `1u`.                                               |
 | `commissionRate`    | [Decimal](#decimal)          | Commission rate.                                                                       |
 | `delegatedCount`    | `uint32`                     | Number of accounts delegating to this validator.                                       |
@@ -891,7 +891,7 @@ The validator queue (i.e. validators with status `ValidatorQueued`) is a subset 
 ### ActiveValidatorCount
 
 | name            | type     | description                  |
-| --------------- | -------- | ---------------------------- |
+|-----------------|----------|------------------------------|
 | `numValidators` | `uint32` | Number of active validators. |
 
 Since the [active validator set](#validator) is stored in a [Sparse Merkle Tree](#sparse-merkle-tree), there is no compact way of proving that the number of active validators exceeds `MAX_VALIDATORS` without keeping track of the number of active validators. The active validator count is stored in the active validators subtree, and is keyed with `0` (i.e. `0x0000000000000000000000000000000000000000000000000000000000000000`), with the first byte replaced with `ACTIVE_VALIDATORS_SUBTREE_ID`.
@@ -899,7 +899,7 @@ Since the [active validator set](#validator) is stored in a [Sparse Merkle Tree]
 ### ActiveVotingPower
 
 | name          | type     | description          |
-| ------------- | -------- | -------------------- |
+|---------------|----------|----------------------|
 | `votingPower` | `uint64` | Active voting power. |
 
 Since the [active validator set](#validator) is stored in a [Sparse Merkle Tree](#sparse-merkle-tree), there is no compact way of proving the active voting power. The active voting power is stored in the active validators subtree, and is keyed with `1` (i.e. `0x0000000000000000000000000000000000000000000000000000000000000001`), with the first byte replaced with `ACTIVE_VALIDATORS_SUBTREE_ID`.
@@ -907,7 +907,7 @@ Since the [active validator set](#validator) is stored in a [Sparse Merkle Tree]
 ### ProposerBlockReward
 
 | name     | type     | description                                                                    |
-| -------- | -------- | ------------------------------------------------------------------------------ |
+|----------|----------|--------------------------------------------------------------------------------|
 | `reward` | `uint64` | Total block reward (subsidy + fees) in current block so far. Reset each block. |
 
 The current block reward for the proposer is kept track of here. This is keyed with `2` (i.e. `0x0000000000000000000000000000000000000000000000000000000000000002`), with the first byte replaced with `ACTIVE_VALIDATORS_SUBTREE_ID`.
@@ -915,7 +915,7 @@ The current block reward for the proposer is kept track of here. This is keyed w
 ### ProposerInitialVotingPower
 
 | name          | type     | description                                                              |
-| ------------- | -------- | ------------------------------------------------------------------------ |
+|---------------|----------|--------------------------------------------------------------------------|
 | `votingPower` | `uint64` | Voting power of the proposer at the start of each block. Set each block. |
 
 The proposer's voting power at the beginning of the block is kept track of here. This is keyed with `3` (i.e. `0x0000000000000000000000000000000000000000000000000000000000000003`), with the first byte replaced with `ACTIVE_VALIDATORS_SUBTREE_ID`.
@@ -923,7 +923,7 @@ The proposer's voting power at the beginning of the block is kept track of here.
 ### ValidatorQueueHead
 
 | name   | type                | description                                                       |
-| ------ | ------------------- | ----------------------------------------------------------------- |
+|--------|---------------------|-------------------------------------------------------------------|
 | `head` | [Address](#address) | Address of inactive validator at the head of the validator queue. |
 
 The head of the queue for validators that are waiting to become active validators is stored in the inactive validators subtree, and is keyed with `0` (i.e. `0x0000000000000000000000000000000000000000000000000000000000000000`), with the first byte replaced with `INACTIVE_VALIDATORS_SUBTREE_ID`.
@@ -933,7 +933,7 @@ If the queue is empty, `head` is set to the default value (i.e. the hash of the 
 ### PeriodEntry
 
 | name         | type                    | description                                                   |
-| ------------ | ----------------------- | ------------------------------------------------------------- |
+|--------------|-------------------------|---------------------------------------------------------------|
 | `rewardRate` | [Amount](#type-aliases) | Rewards per unit of voting power accumulated so far, in `1u`. |
 
 For explanation on entries, see the [reward distribution rationale document](../rationale/distributing_rewards.md).
@@ -941,7 +941,7 @@ For explanation on entries, see the [reward distribution rationale document](../
 ### Decimal
 
 | name          | type   | description           |
-| ------------- | ------ | --------------------- |
+|---------------|--------|-----------------------|
 | `numerator`   | uint64 | Rational numerator.   |
 | `denominator` | uint64 | Rational denominator. |
 
@@ -950,7 +950,7 @@ Represents a (potentially) non-integer number.
 ### MessagePaid
 
 | name     | type                      | description                                                           |
-| -------- | ------------------------- | --------------------------------------------------------------------- |
+|----------|---------------------------|-----------------------------------------------------------------------|
 | `start`  | `uint64`                  | Share index (in row-major order) of first share paid for (inclusive). |
 | `finish` | `uint64`                  | Share index (in row-major order) of last share paid for (inclusive).  |
 | `next`   | [HashDigest](#hashdigest) | Next transaction ID in the list.                                      |
@@ -958,7 +958,7 @@ Represents a (potentially) non-integer number.
 ### MessagePaidHead
 
 | name   | type                      | description                                                              |
-| ------ | ------------------------- | ------------------------------------------------------------------------ |
+|--------|---------------------------|--------------------------------------------------------------------------|
 | `head` | [HashDigest](#hashdigest) | Transaction hash at the head of the list (has the smallest start index). |
 
 The head of the list of paid message shares is stored in the message share paid subtree, and is keyed with `0` (i.e. `0x0000000000000000000000000000000000000000000000000000000000000000`), with the first byte replaced with `MESSAGE_PAID_SUBTREE_ID`.
@@ -970,7 +970,7 @@ If the paid list is empty, `head` is set to the default value (i.e. the hash of 
 Various [consensus parameters](consensus.md#system-parameters) are committed to in the block header, such a limits and constants.
 
 | name                             | type     | description                               |
-| -------------------------------- | -------- | ----------------------------------------- |
+|----------------------------------|----------|-------------------------------------------|
 | `version`                        | `uint64` | The `VERSION`.                            |
 | `chainID`                        | `uint64` | The `CHAIN_ID`.                           |
 | `shareSize`                      | `uint64` | The `SHARE_SIZE`.                         |

--- a/specs/networking.md
+++ b/specs/networking.md
@@ -1,10 +1,9 @@
-Networking
-===
+# Networking
 
 - [Wire Format](#wire-format)
-    - [AvailableData](#availabledata)
-    - [AvailableDataRow](#availabledatarow)
-    - [WireTxPayForMessage](#wiretxpayformessage)
+  - [AvailableData](#availabledata)
+  - [AvailableDataRow](#availabledatarow)
+  - [WireTxPayForMessage](#wiretxpayformessage)
 
 ## Wire Format
 

--- a/specs/networking.md
+++ b/specs/networking.md
@@ -10,13 +10,13 @@
 ### AvailableData
 
 | name                | type                                      | description   |
-| ------------------- | ----------------------------------------- | ------------- |
+|---------------------|-------------------------------------------|---------------|
 | `availableDataRows` | [AvailableDataRow](#availabledatarow)`[]` | List of rows. |
 
 ### AvailableDataRow
 
 | name     | type                                    | description      |
-| -------- | --------------------------------------- | ---------------- |
+|----------|-----------------------------------------|------------------|
 | `shares` | [Share](./data_structures.md#share)`[]` | Shares in a row. |
 
 ### WireTxPayForMessage

--- a/specs/node_types.md
+++ b/specs/node_types.md
@@ -1,19 +1,18 @@
-Node Types
-===
+# Node Types
 
 - [Node Parameters](#node-parameters)
-    - [Block Headers](#block-headers)
-        - [Compact Block Headers](#compact-block-headers)
-        - [Extended Block Headers](#extended-block-headers)
-    - [Block Bodies](#block-bodies)
-        - [No Bodies](#no-bodies)
-        - [Sampled Bodies](#sampled-bodies)
-        - [Partial Bodies](#partial-bodies)
-        - [Full Bodies](#full-bodies)
-    - [Transactions](#transactions)
-        - [No Transactions](#no-transactions)
-        - [Full Transactions](#full-transactions)
-- [Node Types](#node-types)
+  - [Block Headers](#block-headers)
+    - [Compact Block Headers](#compact-block-headers)
+    - [Extended Block Headers](#extended-block-headers)
+  - [Block Bodies](#block-bodies)
+    - [No Bodies](#no-bodies)
+    - [Sampled Bodies](#sampled-bodies)
+    - [Partial Bodies](#partial-bodies)
+    - [Full Bodies](#full-bodies)
+  - [Transactions](#transactions)
+    - [No Transactions](#no-transactions)
+    - [Full Transactions](#full-transactions)
+- [Node Type Definitions](#node-type-definitions)
 
 ## Node Parameters
 
@@ -31,7 +30,7 @@ Secure under an honest supermajority of validator voting power and a weak subjec
 
 #### Extended Block Headers
 
-Nodes that process extended block headers will download and validate both the [compact block header](#compact-block-headers) and the 
+Nodes that process extended block headers will download and validate both the [compact block header](#compact-block-headers) and the
 [`availabledataheader`](./data_structures.md##availabledataheader) [block](./data_structures.md#block) field. These nodes can perform Data Availability Sampling on [block bodies](#block-bodies), and their security assumptions depend on how block bodies are handled.
 
 ### Block Bodies
@@ -76,9 +75,10 @@ Nodes that wish to produce new blocks must know the [chain state](./data_structu
 
 At most secure under a weak subjectivity assumption.
 
-## Node Types
+## Node Type Definitions
 
 For convenience, we will define several common parameter configurations:
+
 1. [Full nodes](https://en.bitcoin.it/wiki/Full_node) provide the strongest security guarantees. Block bodies do not need to be stored.
     - Block headers: [Extended Block Headers](#extended-block-headers)
     - Block bodies: [Full Bodies](#full-bodies)


### PR DESCRIPTION
Use [markdownlint](https://github.com/DavidAnson/markdownlint) and [Markdown Table Prettifier](https://github.com/darkriszty/MarkdownTablePrettify-VSCodeExt), and document formatting guidelines.
