### PR TITLE
Make GitHub action run on push or PR update, exclusive

### DIFF
--- a/.github/workflows/markdown_link_checker.yml
+++ b/.github/workflows/markdown_link_checker.yml
@@ -1,6 +1,12 @@
 name: Check Markdown links
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - *
+  pull_request:
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/markdown_link_checker.yml
+++ b/.github/workflows/markdown_link_checker.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - *
+      - v*
   pull_request:
 
 jobs:


### PR DESCRIPTION
Set markdown link check action to run on pushes to master (and pushes to tags) and pull request updates, instead of any push (including to PR branches). This prevents the action from running twice in a PR.

(You can see redundant running of duplicate action [here](https://github.com/lazyledger/lazyledger-specs/pull/138/commits/2f679a0bc3f8a87473a12999b66d9347cec1384e))