### PR TITLE
Fix non-interactive empty share message NID requirement

### DIFF
--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -552,7 +552,7 @@ In the example below, two messages (of lengths 2 and 1, respectively) are placed
 
 ![fig: Original data: messages.](./figures/rs2d_originaldata_message.svg)
 
-The non-interactive default rules may introduce empty shares that do not belong to any message (in the example above, the top-right share is empty). These are zeroes with namespace ID equal to the either [`TAIL_TRANSACTION_PADDING_NAMESPACE_ID`](./consensus.md#constants) if between a request with a reserved namespace ID and a message, or the namespace ID of the previous message plus `1`. See the [rationale doc](../rationale/message_block_layout.md) for more info.
+The non-interactive default rules may introduce empty shares that do not belong to any message (in the example above, the top-right share is empty). These are zeroes with namespace ID equal to the either [`TAIL_TRANSACTION_PADDING_NAMESPACE_ID`](./consensus.md#constants) if between a request with a reserved namespace ID and a message, or the namespace ID of the previous message if succeeded by a message. See the [rationale doc](../rationale/message_block_layout.md) for more info.
 
 ## Available Data
 


### PR DESCRIPTION
This reversion was missed here https://github.com/lazyledger/lazyledger-specs/commit/6d9648a454bcbfef79172152a4f129253cb7962d#diff-1da55b51e3377610ee9d688350d2e78dce2378036f534f67d63e873229e16f5a