### PR TITLE
Prepend length to messages too

### DIFF
--- a/specs/data_structures.md
+++ b/specs/data_structures.md
@@ -526,7 +526,7 @@ Then,
 1. For each of `transactionData`, `intermediateStateRootData`, and `evidenceData`, [serialize](#serialization):
     1. For each request in the list:
         1. [Serialize](#serialization) the request (individually).
-        1. Compute the length of each serialized request, [serialize the length](#share), and pre-pend the serialized request with its serialized length.
+        1. Compute the length of each serialized request, [serialize the length](#serialization), and pre-pend the serialized request with its serialized length.
     1. Split up the length/request pairs into [`SHARE_SIZE`](./consensus.md#constants)`-`[`NAMESPACE_ID_BYTES`](./consensus.md#constants)`-`[`SHARE_RESERVED_BYTES`](./consensus.md#constants)-byte chunks.
     1. Create a [share](#share) out of each chunk. This data has a _reserved_ namespace ID, so the first [`NAMESPACE_ID_BYTES`](./consensus.md#constants)`+`[`SHARE_RESERVED_BYTES`](./consensus.md#constants) bytes for these shares must be [set specially](#share).
 1. Concatenate the lists of shares in the order: transactions, intermediate state roots, evidence.
@@ -537,7 +537,14 @@ These shares are arranged in the [first quadrant](#2d-reed-solomon-encoding-sche
 
 ![fig: Original data: reserved.](./figures/rs2d_originaldata_reserved.svg)
 
-Each message in the list `messageData` is _independently_ serialized and split into [`SHARE_SIZE`](./consensus.md#constants)`-`[`NAMESPACE_ID_BYTES`](./consensus.md#constants)-byte shares, with the first [`NAMESPACE_ID_BYTES`](./consensus.md#constants) [set to the namespace ID](#share). For each message, it is placed in the available data matrix, with row-major order, as follows:
+Each message in the list `messageData`:
+
+1. [Serialize](#serialization) the message (individually).
+1. Compute the length of each serialized message, [serialize the length](#serialization), and pre-pend the serialized message with its serialized length.
+1. Split up the length/message pairs into [`SHARE_SIZE`](./consensus.md#constants)`-`[`NAMESPACE_ID_BYTES`](./consensus.md#constants)-byte chunks.
+1. Create a [share](#share) out of each chunk. The first [`NAMESPACE_ID_BYTES`](./consensus.md#constants) bytes for these shares is [set to the namespace ID](#share).
+
+For each message, it is placed in the available data matrix, with row-major order, as follows:
 
 1. Place the first share of the message at the next unused location in the matrix, then place the remaining shares in the following locations.
 


### PR DESCRIPTION
Similar to transactions, prepend the length to messages too. This allows splitting the block into messages without actually parsing transactions (i.e. it saves ABCI calls in the implementation).