### PR TITLE
Add Proof of Lock round to proposal struct

### DIFF
--- a/specs/proto/consensus.proto
+++ b/specs/proto/consensus.proto
@@ -16,6 +16,14 @@ enum SignedMsgType {
   SignedMsgTypeProposal = 32;
 }
 
+// https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#availabledataheader
+message AvailableDataHeader {
+  // array of 32-byte hashes
+  repeated bytes row_roots = 1;
+  // array of 32-byte hashes
+  repeated bytes col_roots = 2;
+}
+
 message ConsensusProposal {
   SignedMsgType type = 1;
   int64 height = 2;
@@ -27,6 +35,7 @@ message ConsensusProposal {
   google.protobuf.Timestamp timestamp = 6;
   // 64-byte signature
   bytes proposer_signature = 7;
+  AvailableDataHeader da_header = 8;
 }
 
 message ConsensusVote {

--- a/specs/proto/consensus.proto
+++ b/specs/proto/consensus.proto
@@ -36,7 +36,9 @@ message ConsensusVote {
   // 32-byte hash
   bytes header_hash = 4;
   google.protobuf.Timestamp timestamp = 5;
+  // 32-byte hash
   bytes validator_address = 6;
+  int32 validator_index = 7;
   // 64-byte signature
-  bytes signature = 7;
+  bytes signature = 8;
 }

--- a/specs/proto/consensus.proto
+++ b/specs/proto/consensus.proto
@@ -4,52 +4,39 @@ import "google/protobuf/timestamp.proto";
 
 // Define wire types for consensus messages.
 
-// https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#consensusversion
-message ConsensusVersion {
-  uint64 block = 1;
-  uint64 app = 2;
-}
+// SignedMsgType is a type of signed message in the consensus.
+enum SignedMsgType {
+  SignedMsgTypeUnknown = 0;
 
-// https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#availabledataheader
-message AvailableDataHeader {
-  // array of 32-byte hashes
-  repeated bytes row_roots = 1;
-  // array of 32-byte hashes
-  repeated bytes col_roots = 2;
+  // Votes
+  SignedMsgTypePrevote = 1;
+  SignedMsgTypePrecommit = 2;
+
+  // Proposals
+  SignedMsgTypeProposal = 32;
 }
 
 message ConsensusProposal {
-  int64 height = 1;
-  int32 round = 2;
-  google.protobuf.Timestamp timestamp = 3;
+  SignedMsgType type = 1;
+  int64 height = 2;
+  int32 round = 3;
+  int32 pol_round = 4;
   // 32-byte hash
-  bytes last_header_hash = 4;
-  // 32-byte hash
-  bytes last_commit_hash = 5;
-  // 32-byte hash
-  bytes consensus_hash = 6;
-  // 32-byte hash
-  bytes state_commitment = 7;
-  uint64 available_data_original_shares_used = 8;
-  AvailableDataHeader available_data_header = 9;
+  // Proposed block header
+  bytes header_hash = 5;
+  google.protobuf.Timestamp timestamp = 6;
   // 64-byte signature
-  bytes proposer_signature = 10;
-}
-
-enum CommitFlag {
-  CommitFlagNone = 0;
-  CommitFlagAbsent = 1;
-  CommitFlagCommit = 2;
-  CommitFlagNil = 3;
+  bytes proposer_signature = 7;
 }
 
 message ConsensusVote {
-  CommitFlag commit_flag = 1;
+  SignedMsgType type = 1;
   int64 height = 2;
   int32 round = 3;
   // 32-byte hash
   bytes header_hash = 4;
   google.protobuf.Timestamp timestamp = 5;
+  bytes validator_address = 6;
   // 64-byte signature
-  bytes signature = 6;
+  bytes signature = 7;
 }


### PR DESCRIPTION
Fixes #153 and #154.

This adds the `POLRound` field to consensus proposals. It also refactors [proposals](https://github.com/lazyledger/lazyledger-core/blob/66dd73241e508bc439679afd49683282f8d47b5c/proto/tendermint/types/types.proto#L188-L198) and [votes](https://github.com/lazyledger/lazyledger-core/blob/66dd73241e508bc439679afd49683282f8d47b5c/proto/tendermint/types/types.proto#L155-L168) to conform to the implementation.

~~One difference between the implementation and this PR is the removal of the `available_data_header` field from proposals: https://github.com/lazyledger/lazyledger-specs/compare/adlerjohn/polround?expand=1#diff-48a78bd7e15d8c7211897da188db99d6576a27e125cbde564ae0238ae66e9e94L34~~

~~While the implementation [currently](https://github.com/lazyledger/lazyledger-core/blob/66dd73241e508bc439679afd49683282f8d47b5c/types/proposal.go#L33) has this field, that shouldn't be the case. The rest of the block header is distributed separately from the proposal, which [only commits to the block header](https://github.com/lazyledger/lazyledger-core/blob/66dd73241e508bc439679afd49683282f8d47b5c/types/proposal.go#L30). This is being changed in https://github.com/lazyledger/lazyledger-core/pull/312.~~