### PR TITLE
Move header and DA header into proposal

### DIFF
--- a/specs/networking.md
+++ b/specs/networking.md
@@ -24,6 +24,31 @@
 
 Defined as `ConsensusProposal` [here](./proto/consensus.proto).
 
+When receiving a new block proposal `proposal` from the network, the following steps are performed in order. _Must_ indicates that peers must be blacklisted (to prevent DoS attacks) and _should_ indicates that the network message can simply be ignored.
+
+1. `proposal.type` must be a `SignedMsgType`.
+1. `proposal.round` is processed identically to Tendermint.
+1. `proposal.pol_round` is processed identically to Tendermint.
+1. `proposal.header` must be well-formed.
+1. `proposal.header.version.block` must be [`VERSION_BLOCK`](./consensus.md#constants).
+1. `proposal.header.version.app` must be [`VERSION_APP`](./consensus.md#constants).
+1. `proposal.header.height` should be previous known height + 1.
+1. `proposal.header.chain_id` must be [`CHAIN_ID`](./consensus.md#constants).
+1. `proposal.header.time` is processed identically to Tendermint.
+1. `proposal.header.last_header_hash` must be previous block's header hash.
+1. `proposal.header.last_commit_hash` must be the previous block's commit hash.
+1. `proposal.header.consensus_hash` must be the hash of [consensus parameters](./data_structures.md#header).
+1. `proposal.header.state_commitment` must be the state root after applying the previous block's transactions.
+1. `proposal.header.available_data_original_shares_used` must be at most [`AVAILABLE_DATA_ORIGINAL_SQUARE_MAX ** 2`](./consensus.md#constants).
+1. `proposal.header.available_data_root` must be the [root](./data_structures.md#availabledataheader) of `proposal.da_header`.
+1. `proposal.header.proposer_address` must be the [correct leader](./consensus.md#leader-selection).
+1. `proposal.da_header` must be well-formed.
+1. The number of elements in `proposal.da_header.row_roots` and `proposal.da_header.row_roots` must be equal.
+1. The number of elements in `proposal.da_header.row_roots` must be the same as computed [here](./data_structures.md#header).
+1. For [full nodes](./node_types.md#node-type-definitions), `proposal.da_header` must be the result of computing the roots of the shares (received separately).
+1. For [light nodes](./node_types.md#node-type-definitions), `proposal.da_header` should be sampled from for availability.
+1. `proposal.proposer_signature` must be a valid [digital signature](./data_structures.md#public-key-cryptography) over the header hash of `proposal.header` that recovers to `proposal.header.proposer_address`.
+
 ### WireTxPayForMessage
 
 Defined as `WireTxPayForMessage` as a [wire type](./proto/wire.proto).

--- a/specs/networking.md
+++ b/specs/networking.md
@@ -3,6 +3,7 @@
 - [Wire Format](#wire-format)
   - [AvailableData](#availabledata)
   - [AvailableDataRow](#availabledatarow)
+  - [ConsensusProposal](#consensusproposal)
   - [WireTxPayForMessage](#wiretxpayformessage)
 
 ## Wire Format
@@ -18,6 +19,10 @@
 | name     | type                                    | description      |
 |----------|-----------------------------------------|------------------|
 | `shares` | [Share](./data_structures.md#share)`[]` | Shares in a row. |
+
+### ConsensusProposal
+
+Defined as `ConsensusProposal` [here](./proto/consensus.proto).
 
 ### WireTxPayForMessage
 

--- a/specs/networking.md
+++ b/specs/networking.md
@@ -45,9 +45,9 @@ When receiving a new block proposal `proposal` from the network, the following s
 1. `proposal.da_header` must be well-formed.
 1. The number of elements in `proposal.da_header.row_roots` and `proposal.da_header.row_roots` must be equal.
 1. The number of elements in `proposal.da_header.row_roots` must be the same as computed [here](./data_structures.md#header).
+1. `proposal.proposer_signature` must be a valid [digital signature](./data_structures.md#public-key-cryptography) over the header hash of `proposal.header` that recovers to `proposal.header.proposer_address`.
 1. For [full nodes](./node_types.md#node-type-definitions), `proposal.da_header` must be the result of computing the roots of the shares (received separately).
 1. For [light nodes](./node_types.md#node-type-definitions), `proposal.da_header` should be sampled from for availability.
-1. `proposal.proposer_signature` must be a valid [digital signature](./data_structures.md#public-key-cryptography) over the header hash of `proposal.header` that recovers to `proposal.header.proposer_address`.
 
 ### WireTxPayForMessage
 

--- a/specs/proto/consensus.proto
+++ b/specs/proto/consensus.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 
+import "types.proto";
+
 // Define wire types for consensus messages.
 
 // SignedMsgType is a type of signed message in the consensus.
@@ -16,26 +18,15 @@ enum SignedMsgType {
   SignedMsgTypeProposal = 32;
 }
 
-// https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#availabledataheader
-message AvailableDataHeader {
-  // array of 32-byte hashes
-  repeated bytes row_roots = 1;
-  // array of 32-byte hashes
-  repeated bytes col_roots = 2;
-}
-
 message ConsensusProposal {
   SignedMsgType type = 1;
-  int64 height = 2;
-  int32 round = 3;
-  int32 pol_round = 4;
+  int32 pol_round = 2;
   // 32-byte hash
   // Proposed block header
-  bytes header_hash = 5;
-  google.protobuf.Timestamp timestamp = 6;
+  Header header = 3;
+  AvailableDataHeader da_header = 4;
   // 64-byte signature
-  bytes proposer_signature = 7;
-  AvailableDataHeader da_header = 8;
+  bytes proposer_signature = 5;
 }
 
 message ConsensusVote {

--- a/specs/proto/consensus.proto
+++ b/specs/proto/consensus.proto
@@ -20,13 +20,14 @@ enum SignedMsgType {
 
 message ConsensusProposal {
   SignedMsgType type = 1;
-  int32 pol_round = 2;
+  int32 round = 2;
+  int32 pol_round = 3;
   // 32-byte hash
   // Proposed block header
-  Header header = 3;
-  AvailableDataHeader da_header = 4;
+  Header header = 4;
+  AvailableDataHeader da_header = 5;
   // 64-byte signature
-  bytes proposer_signature = 5;
+  bytes proposer_signature = 6;
 }
 
 message ConsensusVote {

--- a/specs/proto/types.proto
+++ b/specs/proto/types.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+// Define data structures.
+
+// https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#header
+message Header {
+  ConsensusVersion version = 1;
+  string chain_id = 2;
+  int64 height = 3;
+  google.protobuf.Timestamp time = 4;
+  // 32-byte hash
+  BlockID last_header_hash = 5;
+  // 32-byte hash
+  bytes last_commit_hash = 6;
+  // 32-byte hash
+  bytes consensus_hash = 7;
+  // 32-byte hash
+  bytes state_commitment = 8;
+  uint64 available_data_original_shares_used = 9;
+  // 32-byte hash
+  bytes available_data_root = 10;
+  bytes proposer_address = 11;
+}
+
+// https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#consensusversion
+message ConsensusVersion {
+  uint64 block = 1;
+  uint64 app = 2;
+}
+
+// https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#availabledataheader
+message AvailableDataHeader {
+  // array of 32-byte hashes
+  repeated bytes row_roots = 1;
+  // array of 32-byte hashes
+  repeated bytes col_roots = 2;
+}


### PR DESCRIPTION
Fixes #163.

This optimization reduces the number of network round trips by putting both the header and DA header directly into the proposal, so that a single network message is needed to get everything except the block body.

Note that canonicalization is explicitly not addressed here, but will be in #94. Properly abstracted, canonicalization should only affect signature verification and initial network handshake, so _should_ be unimportant for processing.