### PR TITLE
Add CI action to deploy book to GitHub pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,43 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.8'
+
+      - run: mdbook build docs
+
+      - name: Deploy latest
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/book
+          destination_dir: latest
+        if: github.ref == 'refs/heads/master'
+
+      - name: Get tag
+        id: branch_name
+        run: |
+          echo ::set-output name=BRANCH_NAME::${GITHUB_REF#refs/tags/}
+        if: startsWith(github.ref, 'refs/tags')
+
+      - name: Deploy tag
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/book
+          destination_dir: ${{ steps.branch_name.outputs.BRANCH_NAME }}
+        if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
Follow up on #165. This action will automatically deploy `master` to `https://lazyledger.github.io/lazyledger-specs/latest` and tags to `https://lazyledger.github.io/lazyledger-specs/<tag>`. (Unfortunately no good way to preview the effects of this action until it runs.)